### PR TITLE
Refactor state to main process

### DIFF
--- a/docs/plans/development-plan-v1.md
+++ b/docs/plans/development-plan-v1.md
@@ -371,9 +371,15 @@ interface AppSettings {
     testPosition: { x: number; y: number }
     testSize: { width: number; height: number }
     testDuration: number
-    testStyle: string
+    testStyle: {
+      backgroundColor: string
+      textColor: string
+      fontSize: number
+      borderRadius: number
+      padding: number
+    }
     enableMultiMonitor: boolean
-    savedPositions: Array<{ name: string; position: Position }>
+    savedPositions: Array<{ name: string; x: number; y: number; timestamp: number }>
   }
   
   // V1 Setup Progress

--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
-import React, { Component, ErrorInfo, ReactNode } from 'react'
+import React, { Component, ErrorInfo } from 'react'
 
 interface Props {
-  children: ReactNode
+  children: React.ReactNode
 }
 
 interface State {

--- a/src/renderer/services/game-template-service.ts
+++ b/src/renderer/services/game-template-service.ts
@@ -1,5 +1,5 @@
 // Game template loading service
-import type { GameTemplate, HUDRegion } from '@shared/types'
+import type { HUDRegion } from '@shared/types'
 
 export interface RavenswatchTemplate {
   gameInfo: {
@@ -70,32 +70,28 @@ export class GameTemplateService {
       },
       hudRegions: {
         health: {
-          x: 50,
-          y: 50,
-          width: 200,
-          height: 50,
-          description: 'Player health bar location'
+          name: 'health',
+          coordinates: { x: 50, y: 50, width: 200, height: 50 },
+          priority: 'high',
+          analysisType: 'status'
         },
         mana: {
-          x: 50,
-          y: 100,
-          width: 200,
-          height: 30,
-          description: 'Player mana/energy bar location'
+          name: 'mana',
+          coordinates: { x: 50, y: 100, width: 200, height: 30 },
+          priority: 'medium',
+          analysisType: 'status'
         },
         inventory: {
-          x: 1100,
-          y: 600,
-          width: 180,
-          height: 180,
-          description: 'Inventory panel location'
+          name: 'inventory',
+          coordinates: { x: 1100, y: 600, width: 180, height: 180 },
+          priority: 'low',
+          analysisType: 'items'
         },
         minimap: {
-          x: 1150,
-          y: 50,
-          width: 130,
-          height: 130,
-          description: 'Minimap location'
+          name: 'minimap',
+          coordinates: { x: 1150, y: 50, width: 130, height: 130 },
+          priority: 'low',
+          analysisType: 'navigation'
         }
       },
       analysisPrompts: {

--- a/src/renderer/services/tts-service.ts
+++ b/src/renderer/services/tts-service.ts
@@ -26,8 +26,8 @@ export class TTSService {
   private async initializeVoices(): Promise<void> {
     return new Promise((resolve) => {
       const loadVoices = () => {
-        const speechVoices = this.synthesis.getVoices()
-        this.voices = speechVoices.map(voice => ({
+        const available = this.synthesis.getVoices()
+        this.voices = available.map(voice => ({
           name: voice.name,
           lang: voice.lang,
           default: voice.default
@@ -37,7 +37,7 @@ export class TTSService {
       }
 
       // Chrome loads voices asynchronously
-      if (speechVoices.length > 0) {
+      if (this.synthesis.getVoices().length > 0) {
         loadVoices()
       } else {
         this.synthesis.addEventListener('voiceschanged', loadVoices, { once: true })

--- a/src/renderer/stores/app-store.ts
+++ b/src/renderer/stores/app-store.ts
@@ -66,28 +66,17 @@ interface GameCoachState {
 }
 
 // Helper: Sync state to overlay if in main window
-function syncStateToOverlayIfMain(get: any) {
-  if (window?.electronAPI?.syncStateToOverlay && window.location.hash !== '#overlay') {
-    const state = get();
-    window.electronAPI.syncStateToOverlay({
-      gameDetection: state.gameDetection,
-      gameState: state.gameState,
-      isAnalyzing: state.isAnalyzing,
-      lastAnalysis: state.lastAnalysis,
-    });
-  }
-}
 
 export const useGameCoachStore = create<GameCoachState>()(
   subscribeWithSelector((set, get) => ({    // Initial settings
-    settings: {
-      llmProvider: 'openai',
-      openaiApiKey: '',
-      geminiApiKey: '',
-      overlayEnabled: true,
-      ttsEnabled: false,
-      adviceFrequency: 5,
-      overlayPosition: { x: 20, y: 20 },
+      settings: {
+        llmProvider: 'openai',
+        openaiApiKey: '',
+        geminiApiKey: '',
+        overlayEnabled: true,
+        ttsEnabled: false,
+        adviceFrequency: 5,
+        overlayPosition: { x: 20, y: 20 },
       // Phase 3: Advanced TTS Settings
       ttsVoice: 'default',
       ttsSpeed: 1.0,
@@ -101,9 +90,45 @@ export const useGameCoachStore = create<GameCoachState>()(
       autoHideDelay: 8,
       // Phase 3: Performance Settings
       frameProcessingQuality: 'medium',
-      enableHUDRegionDetection: true,
-      maxAdviceHistory: 50,
-    },
+        enableHUDRegionDetection: true,
+        maxAdviceHistory: 50,
+        customInstructions: {
+          systemPrompt: '',
+          gameSpecificPrompts: {},
+          activeTemplate: '',
+          enableVariableSubstitution: true,
+          customTemplates: [],
+        },
+        captureSettings: {
+          selectedSource: null,
+          region: null,
+          quality: 'medium',
+          frameRate: 30,
+          compression: 80,
+          autoDetectGames: true,
+        },
+        overlayTesting: {
+          testPosition: { x: 100, y: 100 },
+          testSize: { width: 300, height: 100 },
+          testDuration: 5000,
+          testStyle: {
+            backgroundColor: 'rgba(0, 0, 0, 0.8)',
+            textColor: 'white',
+            fontSize: 14,
+            borderRadius: 8,
+            padding: 16,
+          },
+          enableMultiMonitor: false,
+          savedPositions: [],
+        },
+        setupProgress: {
+          isComplete: false,
+          completedSteps: [],
+          setupStartTime: 0,
+          setupCompletionTime: 0,
+          firstSessionComplete: false,
+        },
+      },
 
     updateSettings: (newSettings) =>
       set((state) => ({
@@ -252,7 +277,6 @@ export const useGameCoachStore = create<GameCoachState>()(
     },
     setLastAnalysis: (analysis) => {
       set({ lastAnalysis: analysis })
-      syncStateToOverlayIfMain(get);
     },
 
     // Game detection initialization
@@ -260,7 +284,6 @@ export const useGameCoachStore = create<GameCoachState>()(
     gameDetection: null,
     setGameDetection: (detection) => {
       set({ gameDetection: detection })
-      syncStateToOverlayIfMain(get);
     },    startGameDetection: () => {
       console.log('Store: startGameDetection() called')
       const { gameDetector, updateGameState } = get()

--- a/src/renderer/stores/sync-store.ts
+++ b/src/renderer/stores/sync-store.ts
@@ -146,10 +146,16 @@ export const useSyncGameCoachStore = create<SyncGameCoachState>()(
       overlayTesting: {
         testPosition: { x: 100, y: 100 },
         testSize: { width: 300, height: 100 },
-        testDuration: 5,
-        testStyle: 'dark',
+        testDuration: 5000,
+        testStyle: {
+          backgroundColor: 'rgba(0, 0, 0, 0.8)',
+          textColor: 'white',
+          fontSize: 14,
+          borderRadius: 8,
+          padding: 16,
+        },
         enableMultiMonitor: false,
-        savedPositions: []
+        savedPositions: [],
       },
       // V1: Setup Progress defaults
       setupProgress: {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1,5 +1,6 @@
 // Type definitions for the renderer process
 export * from '@shared/types'
+import type { ScreenSource, Advice, GameState, AppSettings } from '@shared/types'
 
 // Additional renderer-specific types
 export interface UIState {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -54,9 +54,15 @@ export interface AppSettings {
     testPosition: { x: number; y: number }
     testSize: { width: number; height: number }
     testDuration: number
-    testStyle: string
+    testStyle: {
+      backgroundColor: string
+      textColor: string
+      fontSize: number
+      borderRadius: number
+      padding: number
+    }
     enableMultiMonitor: boolean
-    savedPositions: Array<{ name: string; position: { x: number; y: number } }>
+    savedPositions: Array<{ name: string; x: number; y: number; timestamp: number }>
   }
   // V1: Setup Progress
   setupProgress: {

--- a/tests/VariableSubstitution.test.tsx
+++ b/tests/VariableSubstitution.test.tsx
@@ -8,6 +8,7 @@ describe('VariableSubstitution component', () => {
   const template: InstructionTemplate = {
     id: 't1',
     name: 'Test Template',
+    description: 'desc',
     category: 'general',
     systemPrompt: 'Context: ${gameContext}\nStatus: ${playerStatus}',
     variables: { gameContext: 'Game context', playerStatus: 'Player status' },

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  ipcMain: { handle: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp') },
+}))
+
+import { StateManager } from '../src/main/state-manager'
+import type { GameDetectionResult } from '../src/shared/types'
+
+describe('StateManager', () => {
+  it('updates game detection and notifies subscribers', () => {
+    const sm = new StateManager({ enableIPC: false, loadSettings: false })
+    const updates: any[] = []
+    sm.subscribe(state => updates.push(state))
+
+    const detection: GameDetectionResult = {
+      isGameRunning: true,
+      confidence: 1,
+      detectionMethod: 'test',
+    }
+
+    sm.setGameDetection(detection)
+
+    expect(sm.getGameDetection()).toEqual(detection)
+    expect(sm.getGameState().isRavenswatchDetected).toBe(true)
+    expect(updates.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('updates settings', () => {
+    const sm = new StateManager({ enableIPC: false, loadSettings: false })
+    sm.setSettings({ overlayEnabled: false })
+    expect(sm.getSettings().overlayEnabled).toBe(false)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
       "@main/*": ["src/main/*"],
       "@renderer/*": ["src/renderer/*"],
       "@shared/*": ["src/shared/*"]
-    }
+    },
+    "types": ["vitest/globals"]
   },
   "include": [
     "src/renderer/**/*",


### PR DESCRIPTION
## Summary
- refactor StateManager to be instantiated with optional IPC and settings loading so it can be tested
- export the StateManager class and add a default export
- add unit tests for the StateManager
- update overlay testing types and defaults
- fix TypeScript errors across renderer services and store

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684074de66d08326a642f601ceef6980