### PR TITLE
Add pluggable settings storage

### DIFF
--- a/src/main/settings-storage.ts
+++ b/src/main/settings-storage.ts
@@ -1,0 +1,37 @@
+import { app } from 'electron'
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import type { AppSettings } from '../shared/types'
+
+export interface SettingsStorage {
+  load(): Promise<Partial<AppSettings>>
+  save(settings: AppSettings): Promise<void>
+}
+
+export class FileSettingsStorage implements SettingsStorage {
+  private filePath: string
+
+  constructor(filePath: string = path.join(app.getPath('userData'), 'settings.json')) {
+    this.filePath = filePath
+  }
+
+  async load(): Promise<Partial<AppSettings>> {
+    try {
+      const data = await fs.readFile(this.filePath, 'utf-8')
+      return JSON.parse(data) as Partial<AppSettings>
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        return {}
+      }
+      throw error
+    }
+  }
+
+  async save(settings: AppSettings): Promise<void> {
+    await fs.writeFile(this.filePath, JSON.stringify(settings, null, 2))
+  }
+}
+
+export const defaultSettingsStorage = new FileSettingsStorage()
+
+export default FileSettingsStorage

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -7,11 +7,21 @@ vi.mock('electron', () => ({
 }))
 
 import { StateManager } from '../src/main/state-manager'
-import type { GameDetectionResult } from '../src/shared/types'
+import type { GameDetectionResult, AppSettings } from '../src/shared/types'
+import type { SettingsStorage } from '../src/main/settings-storage'
+
+class MemorySettingsStorage implements SettingsStorage {
+  data: Partial<AppSettings> = {}
+  load = vi.fn(async () => this.data)
+  save = vi.fn(async (settings: AppSettings) => {
+    this.data = settings
+  })
+}
 
 describe('StateManager', () => {
   it('updates game detection and notifies subscribers', () => {
-    const sm = new StateManager({ enableIPC: false, loadSettings: false })
+    const storage = new MemorySettingsStorage()
+    const sm = new StateManager({ enableIPC: false, loadSettings: false }, storage)
     const updates: any[] = []
     sm.subscribe(state => updates.push(state))
 
@@ -28,9 +38,19 @@ describe('StateManager', () => {
     expect(updates.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('updates settings', () => {
-    const sm = new StateManager({ enableIPC: false, loadSettings: false })
+  it('updates settings and persists via storage', async () => {
+    const storage = new MemorySettingsStorage()
+    const sm = new StateManager({ enableIPC: false, loadSettings: false }, storage)
     sm.setSettings({ overlayEnabled: false })
+    expect(sm.getSettings().overlayEnabled).toBe(false)
+    expect(storage.save).toHaveBeenCalled()
+  })
+
+  it('loads settings from storage', async () => {
+    const storage = new MemorySettingsStorage()
+    storage.data = { overlayEnabled: false }
+    const sm = new StateManager({ enableIPC: false, loadSettings: false }, storage)
+    await (sm as any).loadSettingsFromDisk()
     expect(sm.getSettings().overlayEnabled).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- create `SettingsStorage` interface with JSON file implementation
- allow `StateManager` to inject a `SettingsStorage` instance
- persist settings using the injected storage
- test `StateManager` with in-memory storage

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840fe488cd083269d55ad0e40f20133