### PR TITLE
Implement WindowManager and delegate window logic

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,21 +1,20 @@
-import { app, BrowserWindow, ipcMain, desktopCapturer, screen } from 'electron'
-import * as path from 'path'
+import { app, BrowserWindow, ipcMain, desktopCapturer } from 'electron'
 import { setupIPCHandlers } from './ipc-handlers'
-import { stateManager } from './state-manager'
+import WindowManager from './window-manager'
 
 const isDev = process.env.NODE_ENV === 'development'
 
 class GameCoachApp {
-  private mainWindow: BrowserWindow | null = null
-  private overlayWindow: BrowserWindow | null = null
+  private windowManager: WindowManager
 
   constructor() {
+    this.windowManager = new WindowManager(BrowserWindow, { isDev })
     this.setupApp()
   }
 
   private setupApp() {
     app.whenReady().then(() => {
-      this.createMainWindow()
+      this.windowManager.createMainWindow()
       this.setupIPC()
     })
 
@@ -27,139 +26,17 @@ class GameCoachApp {
 
     app.on('activate', () => {
       if (BrowserWindow.getAllWindows().length === 0) {
-        this.createMainWindow()
+        this.windowManager.createMainWindow()
       }
     })
-  }
-
-  private createMainWindow() {
-    this.mainWindow = new BrowserWindow({
-      width: 1200,
-      height: 800,
-      webPreferences: {
-        nodeIntegration: false,
-        contextIsolation: true,
-        preload: path.join(__dirname, '../preload/preload.js'),
-      },
-      icon: path.join(__dirname, '../../assets/icons/icon.png'),
-      title: 'Ravenswatch Game Coach',
-    })
-
-    // Register window with state manager
-    stateManager.setMainWindow(this.mainWindow)
-
-    // Load the React app
-    if (isDev) {
-      this.mainWindow.loadURL('http://localhost:5173')
-      this.mainWindow.webContents.openDevTools()
-    } else {
-      this.mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'))
-    }
   }
 
   public createOverlayWindow() {
-    console.log('Main: createOverlayWindow() called')
-    
-    if (this.overlayWindow) {
-      console.log('Main: Overlay window already exists, focusing...')
-      this.overlayWindow.focus()
-      return
-    }    console.log('Main: Creating new overlay window...')
-    const primaryDisplay = screen.getPrimaryDisplay()
-    const { width, height } = primaryDisplay.workAreaSize
-    console.log('Main: Primary display size:', width, 'x', height)
-
-    // Calculate position to ensure visibility
-    const overlayWidth = 300
-    const overlayHeight = 150
-    const overlayX = Math.max(0, width - overlayWidth - 20)  // Ensure not off-screen
-    const overlayY = 20
-
-    console.log('Main: Overlay position:', { x: overlayX, y: overlayY, width: overlayWidth, height: overlayHeight })
-
-    this.overlayWindow = new BrowserWindow({
-      width: overlayWidth,
-      height: overlayHeight,
-      x: overlayX,
-      y: overlayY,
-      frame: false,
-      transparent: true,
-      alwaysOnTop: true,
-      skipTaskbar: true,
-      resizable: false,
-      focusable: false,  // Don't steal focus
-      show: false,       // Don't show immediately
-      webPreferences: {
-        nodeIntegration: false,
-        contextIsolation: true,
-        preload: path.join(__dirname, '../preload/preload.js'),
-      },
-    })
-
-    console.log('Main: Overlay window created, loading content...')    // Load overlay content
-    if (isDev) {
-      const overlayURL = 'http://localhost:5173#overlay'
-      console.log('Main: Loading overlay URL (dev):', overlayURL)
-      this.overlayWindow.loadURL(overlayURL)
-    } else {
-      const overlayFile = path.join(__dirname, '../renderer/index.html')
-      console.log('Main: Loading overlay file (prod):', overlayFile)
-      this.overlayWindow.loadFile(overlayFile, {
-        hash: 'overlay'
-      })
-    }
-
-    this.overlayWindow.on('closed', () => {
-      console.log('Main: Overlay window closed')
-      this.overlayWindow = null
-      stateManager.setOverlayWindow(null)
-      stateManager.setOverlayVisible(false)
-    })
-
-    // Add ready-to-show event for debugging
-    this.overlayWindow.once('ready-to-show', () => {
-      console.log('Main: Overlay window ready to show')
-      
-      // Register window with state manager
-      stateManager.setOverlayWindow(this.overlayWindow!)
-      
-      // Ensure window is properly positioned and visible
-      const bounds = this.overlayWindow?.getBounds()
-      console.log('Main: Overlay window bounds:', bounds)
-      
-      // Make sure it's visible and on top
-      this.overlayWindow?.show()
-      this.overlayWindow?.setAlwaysOnTop(true)
-      this.overlayWindow?.moveTop()
-      
-      // Update state manager
-      stateManager.setOverlayVisible(true)
-      
-      console.log('Main: Overlay window shown and moved to top')
-      console.log('Main: Overlay window visible:', this.overlayWindow?.isVisible())
-    })
-
-    // Add error handling
-    this.overlayWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
-      console.error('Main: Overlay window failed to load:', errorCode, errorDescription)
-    })
-
-    this.overlayWindow.webContents.once('did-finish-load', () => {
-      console.log('Main: Overlay window finished loading')
-      // Open DevTools for overlay window to debug React issues
-      if (isDev) {
-        this.overlayWindow?.webContents.openDevTools()
-      }
-    })
+    this.windowManager.createOverlayWindow()
   }
 
   public closeOverlayWindow() {
-    if (this.overlayWindow) {
-      this.overlayWindow.close()
-      this.overlayWindow = null
-      stateManager.setOverlayWindow(null)
-      stateManager.setOverlayVisible(false)
-    }
+    this.windowManager.closeOverlayWindow()
   }
 
   private setupIPC() {
@@ -202,11 +79,11 @@ class GameCoachApp {
   }
 
   public getMainWindow() {
-    return this.mainWindow
+    return this.windowManager.getMainWindow()
   }
 
   public getOverlayWindow() {
-    return this.overlayWindow
+    return this.windowManager.getOverlayWindow()
   }
 }
 

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -1,0 +1,135 @@
+import type { BrowserWindow as ElectronBrowserWindow, BrowserWindowConstructorOptions } from 'electron'
+import { screen } from 'electron'
+import * as path from 'path'
+import { stateManager, type StateManager } from './state-manager'
+
+export interface WindowManagerOptions {
+  isDev?: boolean
+  stateManager?: StateManager
+}
+
+export class WindowManager {
+  private BrowserWindow: typeof ElectronBrowserWindow
+  private isDev: boolean
+  private stateManager: StateManager
+  private mainWindow: ElectronBrowserWindow | null = null
+  private overlayWindow: ElectronBrowserWindow | null = null
+
+  constructor(BrowserWindowClass: typeof ElectronBrowserWindow, options: WindowManagerOptions = {}) {
+    this.BrowserWindow = BrowserWindowClass
+    this.isDev = options.isDev ?? process.env.NODE_ENV === 'development'
+    this.stateManager = options.stateManager ?? stateManager
+  }
+
+  createMainWindow(): ElectronBrowserWindow {
+    const opts: BrowserWindowConstructorOptions = {
+      width: 1200,
+      height: 800,
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        preload: path.join(__dirname, '../preload/preload.js'),
+      },
+      icon: path.join(__dirname, '../../assets/icons/icon.png'),
+      title: 'Ravenswatch Game Coach',
+    }
+
+    this.mainWindow = new this.BrowserWindow(opts)
+    this.stateManager.setMainWindow(this.mainWindow)
+
+    if (this.isDev) {
+      this.mainWindow.loadURL('http://localhost:5173')
+      this.mainWindow.webContents.openDevTools()
+    } else {
+      this.mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'))
+    }
+
+    return this.mainWindow
+  }
+
+  createOverlayWindow(): ElectronBrowserWindow {
+    if (this.overlayWindow) {
+      this.overlayWindow.focus()
+      return this.overlayWindow
+    }
+
+    const { width } = screen.getPrimaryDisplay().workAreaSize
+    const overlayWidth = 300
+    const overlayHeight = 150
+    const overlayX = Math.max(0, width - overlayWidth - 20)
+    const overlayY = 20
+
+    const opts: BrowserWindowConstructorOptions = {
+      width: overlayWidth,
+      height: overlayHeight,
+      x: overlayX,
+      y: overlayY,
+      frame: false,
+      transparent: true,
+      alwaysOnTop: true,
+      skipTaskbar: true,
+      resizable: false,
+      focusable: false,
+      show: false,
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        preload: path.join(__dirname, '../preload/preload.js'),
+      },
+    }
+
+    this.overlayWindow = new this.BrowserWindow(opts)
+
+    if (this.isDev) {
+      this.overlayWindow.loadURL('http://localhost:5173#overlay')
+    } else {
+      this.overlayWindow.loadFile(path.join(__dirname, '../renderer/index.html'), { hash: 'overlay' })
+    }
+
+    this.overlayWindow.on('closed', () => {
+      this.overlayWindow = null
+      this.stateManager.setOverlayWindow(null)
+      this.stateManager.setOverlayVisible(false)
+    })
+
+    this.overlayWindow.once('ready-to-show', () => {
+      this.stateManager.setOverlayWindow(this.overlayWindow!)
+      this.overlayWindow!.show()
+      this.overlayWindow!.setAlwaysOnTop(true)
+      this.overlayWindow!.moveTop()
+      this.stateManager.setOverlayVisible(true)
+    })
+
+    this.overlayWindow.webContents.on('did-fail-load', (_event, code, desc) => {
+      // eslint-disable-next-line no-console
+      console.error('Overlay window failed to load:', code, desc)
+    })
+
+    this.overlayWindow.webContents.once('did-finish-load', () => {
+      if (this.isDev) {
+        this.overlayWindow?.webContents.openDevTools()
+      }
+    })
+
+    return this.overlayWindow
+  }
+
+  closeOverlayWindow(): void {
+    if (this.overlayWindow) {
+      this.overlayWindow.close()
+      this.overlayWindow = null
+      this.stateManager.setOverlayWindow(null)
+      this.stateManager.setOverlayVisible(false)
+    }
+  }
+
+  getMainWindow(): ElectronBrowserWindow | null {
+    return this.mainWindow
+  }
+
+  getOverlayWindow(): ElectronBrowserWindow | null {
+    return this.overlayWindow
+  }
+}
+
+export default WindowManager

--- a/tests/window-manager.test.ts
+++ b/tests/window-manager.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { WindowManager } from '../src/main/window-manager'
+import { StateManager } from '../src/main/state-manager'
+
+class MockBrowserWindow extends EventEmitter {
+  public webContents = {
+    on: vi.fn(),
+    once: vi.fn(),
+    send: vi.fn(),
+    openDevTools: vi.fn(),
+  }
+  public loadURL = vi.fn()
+  public loadFile = vi.fn()
+  public focus = vi.fn()
+  public show = vi.fn()
+  public setAlwaysOnTop = vi.fn()
+  public moveTop = vi.fn()
+  public close = vi.fn()
+  public isVisible = vi.fn(() => true)
+  public isDestroyed = vi.fn(() => false)
+  constructor(public options: any) {
+    super()
+  }
+  getBounds() {
+    return { x: this.options.x ?? 0, y: this.options.y ?? 0, width: this.options.width, height: this.options.height }
+  }
+}
+
+vi.mock('electron', () => ({
+  screen: {
+    getPrimaryDisplay: () => ({ workAreaSize: { width: 800, height: 600 } })
+  },
+  ipcMain: { handle: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp') },
+  BrowserWindow: class {},
+}))
+
+describe('WindowManager', () => {
+  it('creates overlay window and updates state on ready', () => {
+    const sm = new StateManager({ enableIPC: false, loadSettings: false })
+    const wm = new WindowManager(MockBrowserWindow as any, { isDev: false, stateManager: sm })
+    const overlay = wm.createOverlayWindow() as unknown as MockBrowserWindow
+
+    expect(overlay).toBeInstanceOf(MockBrowserWindow)
+    expect(sm.getState().isOverlayVisible).toBe(false)
+
+    overlay.emit('ready-to-show')
+    expect(sm.getState().isOverlayVisible).toBe(true)
+  })
+
+  it('closing overlay window hides overlay', () => {
+    const sm = new StateManager({ enableIPC: false, loadSettings: false })
+    const wm = new WindowManager(MockBrowserWindow as any, { isDev: false, stateManager: sm })
+    const overlay = wm.createOverlayWindow() as unknown as MockBrowserWindow
+    overlay.emit('ready-to-show')
+
+    wm.closeOverlayWindow()
+    expect(sm.getState().isOverlayVisible).toBe(false)
+    expect(wm.getOverlayWindow()).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- add `WindowManager` class to encapsulate window creation
- refactor `main.ts` to delegate all window management to the new class
- add unit tests for `WindowManager`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840fe499e8483268ee88cf21eff8363