### PR TITLE
Add service test coverage

### DIFF
--- a/tests/game-detector.test.ts
+++ b/tests/game-detector.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { GameDetectorService } from '../src/renderer/services/game-detector'
+
+describe('GameDetectorService', () => {
+  it('findGameInSources returns matching source', () => {
+    const svc = new GameDetectorService()
+    const match = (svc as any).findGameInSources([
+      { id: '1', name: 'Ravenswatch Window' },
+      { id: '2', name: 'Other' }
+    ])
+    expect(match?.id).toBe('1')
+  })
+})

--- a/tests/game-template-service.test.ts
+++ b/tests/game-template-service.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { GameTemplateService } from '../src/renderer/services/game-template-service'
+
+const sampleTemplate = {
+  gameInfo: { name: 'R', processName: 'r.exe', windowTitle: 'R', genre: 'g', developer: 'd' },
+  hudRegions: {},
+  analysisPrompts: { tactical: 'tac', strategic: 'str', immediate: 'imm' },
+  gameplayContext: { characterClasses: [], enemyTypes: [], itemCategories: [], statusEffects: [] }
+}
+
+beforeAll(() => {
+  ;(window as any).electronAPI = {
+    loadGameTemplate: vi.fn().mockResolvedValue(sampleTemplate)
+  }
+})
+
+describe('GameTemplateService', () => {
+  it('loads template from electron API', async () => {
+    const svc = new GameTemplateService()
+    const tpl = await svc.loadRavenswatchTemplate()
+    expect(tpl.gameInfo.name).toBe('R')
+  })
+
+  it('returns default when load fails', async () => {
+    const svc = new GameTemplateService()
+    ;(window as any).electronAPI.loadGameTemplate.mockRejectedValueOnce(new Error('fail'))
+    const tpl = await svc.loadRavenswatchTemplate()
+    expect(tpl.gameInfo.name).toBe('Ravenswatch')
+  })
+})

--- a/tests/image-processor.test.ts
+++ b/tests/image-processor.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { ImageProcessor } from '../src/main/image-processor'
+
+const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/5+BFwAI/wObmeUAAAAASUVORK5CYII='
+const sampleBuffer = Buffer.from(pngBase64, 'base64')
+
+const processor = new ImageProcessor()
+
+describe('ImageProcessor', () => {
+  it('processFrame returns resized buffer', async () => {
+    const out = await processor.processFrame(sampleBuffer, { width: 2, height: 2 })
+    expect(out.length).toBeGreaterThan(0)
+    expect(out).not.toEqual(sampleBuffer)
+  })
+
+  it('cropRegion returns buffer of region', async () => {
+    const out = await processor.cropRegion(sampleBuffer, 0, 0, 1, 1)
+    expect(out.length).toBeGreaterThan(0)
+  })
+
+  it('getImageInfo returns metadata', async () => {
+    const info = await processor.getImageInfo(sampleBuffer)
+    expect(info.width).toBeGreaterThan(0)
+    expect(info.height).toBeGreaterThan(0)
+    expect(info.size).toBe(sampleBuffer.length)
+  })
+})

--- a/tests/instruction-template-service.test.ts
+++ b/tests/instruction-template-service.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { InstructionTemplateService } from '../src/renderer/services/instruction-template-service'
+import type { InstructionTemplate } from '../src/shared/types'
+
+describe('InstructionTemplateService', () => {
+  it('adds and removes custom templates', () => {
+    const svc = new InstructionTemplateService()
+    const tpl: InstructionTemplate = {
+      id: '1',
+      name: 'Test',
+      description: '',
+      systemPrompt: 'hello',
+      variables: {},
+      category: 'combat',
+      isBuiltIn: false
+    }
+    svc.addCustomTemplate(tpl)
+    expect(svc.getTemplateById('1')).toEqual(tpl)
+    const removed = svc.removeCustomTemplate('1')
+    expect(removed).toBe(true)
+    expect(svc.getTemplateById('1')).toBeNull()
+  })
+
+  it('substitutes variables in templates', () => {
+    const svc = new InstructionTemplateService()
+    const tpl: InstructionTemplate = {
+      id: '1',
+      name: 'Test',
+      description: '',
+      systemPrompt: 'Use ${name}',
+      variables: {},
+      category: 'combat',
+      isBuiltIn: false
+    }
+    const out = svc.substituteVariables(tpl, { name: 'Hero' })
+    expect(out).toBe('Use Hero')
+  })
+
+  it('validates template fields', () => {
+    const svc = new InstructionTemplateService()
+    const errors = svc.validateTemplate({ name: '', id: '' })
+    expect(errors.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/llm-service.test.ts
+++ b/tests/llm-service.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest'
+import { LLMService, type LLMConfig } from '../src/renderer/services/llm-service'
+
+vi.mock('openai', () => {
+  return {
+    default: class {
+      chat = { completions: { create: vi.fn(async () => ({ choices: [{ message: { content: 'ok' } }] })) } }
+    }
+  }
+})
+
+vi.mock('@google/generative-ai', () => {
+  return {
+    GoogleGenerativeAI: class {
+      constructor(_key: string) {}
+      getGenerativeModel() {
+        return {
+          generateContent: vi.fn(async () => ({ response: { text: () => 'gemini' } }))
+        }
+      }
+    }
+  }
+})
+
+describe('LLMService retryWithBackoff', () => {
+  it('retries until success', async () => {
+    vi.useFakeTimers()
+    const service = new LLMService({
+      openaiApiKey: 'k',
+      geminiApiKey: undefined,
+      preferredProvider: 'openai',
+      maxRetries: 2,
+      timeout: 0
+    } as LLMConfig)
+
+    const op = vi.fn()
+      .mockRejectedValueOnce(new Error('e1'))
+      .mockRejectedValueOnce(new Error('e2'))
+      .mockResolvedValue('done')
+
+    const promise = (service as any).retryWithBackoff(op, 2)
+    await vi.runAllTimersAsync()
+    const result = await promise
+    expect(result).toBe('done')
+    expect(op).toHaveBeenCalledTimes(3)
+    vi.useRealTimers()
+  })
+
+  it('throws after max retries', async () => {
+    vi.useFakeTimers()
+    const service = new LLMService({
+      openaiApiKey: 'k',
+      geminiApiKey: undefined,
+      preferredProvider: 'openai',
+      maxRetries: 1,
+      timeout: 0
+    } as LLMConfig)
+    const op = vi.fn().mockRejectedValue(new Error('fail'))
+    const promise = (service as any).retryWithBackoff(op, 1)
+    promise.catch(() => {})
+    await vi.runAllTimersAsync()
+    await expect(promise).rejects.toThrow('fail')
+    expect(op).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+  })
+})
+
+describe('LLMService calculateConfidence', () => {
+  const service = new LLMService({
+    openaiApiKey: 'k',
+    geminiApiKey: undefined,
+    preferredProvider: 'openai',
+    maxRetries: 0,
+    timeout: 0
+  } as LLMConfig)
+
+  it('returns low confidence for short advice', () => {
+    const c = (service as any).calculateConfidence('short')
+    expect(c).toBeCloseTo(0.1)
+  })
+
+  it('scores higher for long detailed advice', () => {
+    const text = 'Use your ability to attack the enemy and keep your health and mana high while positioning carefully for the next encounter.'
+    const c = (service as any).calculateConfidence(text)
+    expect(c).toBeGreaterThan(0.7)
+    expect(c).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('LLMService provider selection', () => {
+  it('selects preferred provider when configured', () => {
+    const service = new LLMService({
+      openaiApiKey: 'a',
+      geminiApiKey: 'b',
+      preferredProvider: 'gemini',
+      maxRetries: 0,
+      timeout: 0
+    } as LLMConfig)
+
+    const provider = (service as any).selectProvider()
+    expect(provider?.name).toBe('gemini')
+  })
+
+  it('falls back to first available provider in auto mode', () => {
+    const service = new LLMService({
+      openaiApiKey: 'a',
+      geminiApiKey: 'b',
+      preferredProvider: 'auto',
+      maxRetries: 0,
+      timeout: 0
+    } as LLMConfig)
+    const provider = (service as any).selectProvider()
+    expect(provider?.name).toBe('openai')
+  })
+
+  it('returns null when preferred provider missing', () => {
+    const service = new LLMService({
+      geminiApiKey: 'b',
+      preferredProvider: 'openai',
+      maxRetries: 0,
+      timeout: 0
+    } as LLMConfig)
+    const provider = (service as any).selectProvider()
+    expect(provider).toBeNull()
+  })
+})

--- a/tests/screen-capture-renderer.test.ts
+++ b/tests/screen-capture-renderer.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RendererScreenCaptureService } from '../src/renderer/services/screen-capture-renderer'
+
+describe('RendererScreenCaptureService', () => {
+  beforeEach(() => {
+    ;(navigator as any).mediaDevices = {
+      getUserMedia: vi.fn()
+    }
+  })
+
+  it('reports support when getUserMedia exists', () => {
+    expect(RendererScreenCaptureService.isSupported()).toBe(true)
+  })
+
+  it('startCapture returns false on failure', async () => {
+    ;(navigator.mediaDevices.getUserMedia as any).mockRejectedValue(new Error('fail'))
+    const svc = new RendererScreenCaptureService()
+    const result = await svc.startCapture('id1')
+    expect(result).toBe(false)
+  })
+})

--- a/tests/screen-capture.test.ts
+++ b/tests/screen-capture.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ScreenCaptureService } from '../src/main/screen-capture'
+
+vi.mock('electron', () => ({
+  desktopCapturer: {
+    getSources: vi.fn()
+  }
+}))
+
+vi.mock('fs', () => ({
+  writeFileSync: vi.fn()
+}))
+
+import { desktopCapturer } from 'electron'
+import { writeFileSync } from 'fs'
+
+const mockSources = [
+  { id: '1', name: 'Window 1', thumbnail: { toDataURL: () => 'data1' } },
+  { id: '2', name: 'Window 2', thumbnail: { toDataURL: () => 'data2' } }
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  ;(desktopCapturer.getSources as any).mockResolvedValue(mockSources)
+})
+
+describe('ScreenCaptureService', () => {
+  it('maps available sources', async () => {
+    const service = new ScreenCaptureService()
+    const result = await service.getAvailableSources()
+    expect(desktopCapturer.getSources).toHaveBeenCalled()
+    expect(result[0]).toEqual({ id: '1', name: 'Window 1', thumbnail: 'data1' })
+  })
+
+  it('tracks capture state', async () => {
+    const service = new ScreenCaptureService()
+    await service.startCapture('abc')
+    expect(service.isCurrentlyCapturing()).toBe(true)
+    expect(service.getCurrentSourceId()).toBe('abc')
+    await service.stopCapture()
+    expect(service.isCurrentlyCapturing()).toBe(false)
+    expect(service.getCurrentSourceId()).toBeNull()
+  })
+
+  it('saves frame to disk', async () => {
+    const service = new ScreenCaptureService()
+    const path = await service.saveFrameForAnalysis(Buffer.from('hello'))
+    expect(writeFileSync).toHaveBeenCalled()
+    expect(path).toContain('frame_')
+  })
+})

--- a/tests/tts-service.test.ts
+++ b/tests/tts-service.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+
+;(window as any).speechSynthesis = {
+  speaking: false,
+  paused: false,
+  getVoices: () => [{ name: 'Test', lang: 'en', default: true }],
+  speak: () => {},
+  cancel: () => {},
+  pause: () => { (window as any).speechSynthesis.paused = true },
+  resume: () => { (window as any).speechSynthesis.paused = false },
+  addEventListener: (_: string, cb: () => void) => { cb() }
+};
+(window as any).SpeechSynthesisUtterance = function () {};
+
+
+beforeEach(() => {
+  ;(window as any).speechSynthesis = {
+    speaking: false,
+    paused: false,
+    getVoices: () => [{ name: 'Test', lang: 'en', default: true }],
+    speak: () => {},
+    cancel: () => {},
+    pause: () => { (window as any).speechSynthesis.paused = true },
+    resume: () => { (window as any).speechSynthesis.paused = false },
+    addEventListener: (_: string, cb: () => void) => { cb() }
+  };
+  ;(window as any).SpeechSynthesisUtterance = function () {};
+})
+
+describe('TTSService', () => {
+  it('reports support when APIs exist', async () => {
+    const { TTSService } = await import('../src/renderer/services/tts-service')
+    expect(TTSService.isSupported()).toBe(true)
+  })
+
+  it('returns default voice', async () => {
+    const { TTSService } = await import('../src/renderer/services/tts-service')
+    const svc = new TTSService()
+    await (svc as any).initializeVoices()
+    expect(svc.getDefaultVoice()?.name).toBe('Test')
+  })
+
+  it('cleans text for speech', async () => {
+    const { TTSService } = await import('../src/renderer/services/tts-service')
+    const svc = new TTSService()
+    const method = (svc as any).cleanTextForSpeech.bind(svc)
+    const out = method('Attack the npc!')
+    expect(out).toBe('Attack the enemy!')
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for LLM service retry logic, confidence calculation and provider selection
- cover screen capture utilities by mocking Electron APIs
- add tests for image processor and template services
- test renderer capture support and game detector helper
- add lightweight TTS service tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840fe4a1274832687f858b481244b04