### PR TITLE
Refactor services for dependency injection

### DIFF
--- a/src/renderer/services/game-detector.ts
+++ b/src/renderer/services/game-detector.ts
@@ -5,6 +5,19 @@ import {
   calculateConfidence,
 } from './game-detector-utils'
 
+export interface ScreenCaptureAPI {
+  getCaptureSource: () => Promise<any[]>
+}
+
+export const createDefaultScreenCaptureAPI = (): ScreenCaptureAPI => ({
+  getCaptureSource: async () => {
+    if (typeof window !== 'undefined' && window.electronAPI?.getCaptureSource) {
+      return window.electronAPI.getCaptureSource()
+    }
+    return []
+  }
+})
+
 // Re-export for backwards compatibility
 export type { GameWindow, GameDetectionResult }
 
@@ -14,6 +27,11 @@ export class GameDetectorService {
   private detectionCallback?: (result: GameDetectionResult) => void
   private detectionTimer?: NodeJS.Timeout
   private lastDetection?: GameDetectionResult
+  private captureAPI: ScreenCaptureAPI
+
+  constructor(captureAPI: ScreenCaptureAPI = createDefaultScreenCaptureAPI()) {
+    this.captureAPI = captureAPI
+  }
   public startDetection(callback: (result: GameDetectionResult) => void) {
     console.log('GameDetector: startDetection() called')
     this.detectionCallback = callback
@@ -96,22 +114,11 @@ export class GameDetectorService {
       confidence: 0,
       detectionMethod: 'capture-source',
     }
-  }  private async getCaptureSource(): Promise<any[]> {
+  }
+
+  private async getCaptureSource(): Promise<any[]> {
     try {
-      console.log('GameDetector: Checking window.electronAPI availability...')
-      if (!window.electronAPI) {
-        console.error('GameDetector: window.electronAPI is not available!')
-        return []
-      }
-      
-      console.log('GameDetector: window.electronAPI found, calling getCaptureSource()...')
-      if (typeof window.electronAPI.getCaptureSource !== 'function') {
-        console.error('GameDetector: window.electronAPI.getCaptureSource is not a function!')
-        return []
-      }
-      
-      console.log('GameDetector: Calling window.electronAPI.getCaptureSource()...')
-      const sources = await window.electronAPI.getCaptureSource()
+      const sources = await this.captureAPI.getCaptureSource()
       console.log('GameDetector: Total available capture sources:', sources?.length || 0)
       console.log('GameDetector: Available capture sources:', sources?.map((s: any) => ({
         id: s.id,
@@ -196,7 +203,7 @@ export class GameDetectorService {
   public async testCaptureSourcesRaw(): Promise<any[]> {
     console.log('GameDetector: Testing raw capture sources...')
     try {
-      const sources = await window.electronAPI.getCaptureSource()
+      const sources = await this.captureAPI.getCaptureSource()
       console.log('GameDetector: Raw electronAPI result:', sources)
       console.log('GameDetector: Source count:', sources?.length || 0)
       
@@ -217,27 +224,11 @@ export class GameDetectorService {
   // Comprehensive diagnostic test
   public async runDiagnostic(): Promise<void> {
     console.log('\n🔍 === GAME DETECTOR DIAGNOSTIC ===')
-    
-    // Test 1: Check electronAPI availability
-    console.log('1. Checking electronAPI availability...')
-    if (!window.electronAPI) {
-      console.error('❌ window.electronAPI is not available!')
-      return
-    }
-    console.log('✅ window.electronAPI is available')
-    
-    // Test 2: Check getCaptureSource method
-    console.log('2. Checking getCaptureSource method...')
-    if (typeof window.electronAPI.getCaptureSource !== 'function') {
-      console.error('❌ window.electronAPI.getCaptureSource is not a function!')
-      return
-    }
-    console.log('✅ window.electronAPI.getCaptureSource is a function')
-    
-    // Test 3: Test IPC call
-    console.log('3. Testing IPC call...')
+
+    // Test 1: Test capture API call
+    console.log('1. Testing capture API call...')
     try {
-      const sources = await window.electronAPI.getCaptureSource()
+      const sources = await this.captureAPI.getCaptureSource()
       console.log('✅ IPC call successful! Got', sources?.length || 0, 'sources')
       
       if (sources && sources.length > 0) {
@@ -251,8 +242,8 @@ export class GameDetectorService {
       return
     }
     
-    // Test 4: Test detection logic
-    console.log('4. Testing detection logic...')
+    // Test 2: Test detection logic
+    console.log('2. Testing detection logic...')
     try {
       const result = await this.detectRavenswatch()
       console.log('✅ Detection logic successful!')

--- a/src/renderer/stores/app-store.ts
+++ b/src/renderer/stores/app-store.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import type { AppSettings, GameState, Advice, ScreenSource } from '@shared/types'
-import { LLMService, type LLMConfig, type AnalysisResponse } from '../services/llm-service'
-import { GameDetectorService, type GameDetectionResult } from '../services/game-detector'
+import { LLMService, type LLMConfig, type AnalysisResponse, createOpenAIClient, createGeminiClient } from '../services/llm-service'
+import { GameDetectorService, type GameDetectionResult, createDefaultScreenCaptureAPI } from '../services/game-detector'
 
 interface GameCoachState {
   // Settings
@@ -248,7 +248,10 @@ export const useGameCoachStore = create<GameCoachState>()(
 
       try {
         console.log('Store: Creating LLM service instance...')
-        const service = new LLMService(config)
+        const service = new LLMService(config, {
+          openAIFactory: createOpenAIClient,
+          geminiFactory: createGeminiClient,
+        })
         console.log('Store: LLM service created, setting in store...')
         
         set({
@@ -280,7 +283,7 @@ export const useGameCoachStore = create<GameCoachState>()(
     },
 
     // Game detection initialization
-    gameDetector: new GameDetectorService(),
+    gameDetector: new GameDetectorService(createDefaultScreenCaptureAPI()),
     gameDetection: null,
     setGameDetection: (detection) => {
       set({ gameDetection: detection })

--- a/src/renderer/stores/sync-store.ts
+++ b/src/renderer/stores/sync-store.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import type { AppSettings, GameState, Advice } from '@shared/types'
-import { LLMService, type LLMConfig, type AnalysisResponse } from '../services/llm-service'
-import { GameDetectorService, type GameDetectionResult } from '../services/game-detector'
+import { LLMService, type LLMConfig, type AnalysisResponse, createOpenAIClient, createGeminiClient } from '../services/llm-service'
+import { GameDetectorService, type GameDetectionResult, createDefaultScreenCaptureAPI } from '../services/game-detector'
 
 interface SyncGameCoachState {
   // Core state - synchronized with main process
@@ -196,7 +196,7 @@ export const useSyncGameCoachStore = create<SyncGameCoachState>()(
 
     // Services
     llmService: null,
-    gameDetector: new GameDetectorService(),
+    gameDetector: new GameDetectorService(createDefaultScreenCaptureAPI()),
 
     // Initialize store and sync with main process
     initializeStore: async () => {
@@ -391,7 +391,10 @@ export const useSyncGameCoachStore = create<SyncGameCoachState>()(
           hasOpenAI: !!config.openaiApiKey,
           hasGemini: !!config.geminiApiKey
         })
-        const llmService = new LLMService(config)
+        const llmService = new LLMService(config, {
+          openAIFactory: createOpenAIClient,
+          geminiFactory: createGeminiClient,
+        })
         
         console.log('SyncStore: LLM service created, checking readiness...')
         console.log('SyncStore: LLM service ready:', llmService.isReady())

--- a/tests/game-detector-service.test.ts
+++ b/tests/game-detector-service.test.ts
@@ -1,0 +1,24 @@
+//@vitest-environment node
+import { describe, it, expect, vi } from 'vitest'
+import { GameDetectorService } from '../src/renderer/services/game-detector'
+
+const createApi = (sources: any[]) => ({
+  getCaptureSource: vi.fn().mockResolvedValue(sources)
+})
+
+describe('GameDetectorService', () => {
+  it('detects game from capture sources', async () => {
+    const api = createApi([{ id: '1', name: 'Ravenswatch' }])
+    const service = new GameDetectorService(api)
+    const res = await service.manualDetection()
+    expect(api.getCaptureSource).toHaveBeenCalled()
+    expect(res.isGameRunning).toBe(true)
+  })
+
+  it('returns not running when sources empty', async () => {
+    const api = createApi([])
+    const service = new GameDetectorService(api)
+    const res = await service.manualDetection()
+    expect(res.isGameRunning).toBe(false)
+  })
+})

--- a/tests/llm-service.test.ts
+++ b/tests/llm-service.test.ts
@@ -1,0 +1,41 @@
+//@vitest-environment node
+import { describe, it, expect, vi } from 'vitest'
+import { LLMService, type LLMConfig } from '../src/renderer/services/llm-service'
+
+const createMockClient = (fn: any) => ({
+  chat: { completions: { create: fn } }
+})
+
+describe('LLMService retry logic', () => {
+  it('retries failed analyze calls', async () => {
+    vi.useFakeTimers()
+    const mockCreate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail1'))
+      .mockRejectedValueOnce(new Error('fail2'))
+      .mockResolvedValue({ choices: [{ message: { content: 'advice' } }] })
+
+    const config: LLMConfig = {
+      openaiApiKey: 'key',
+      preferredProvider: 'openai',
+      maxRetries: 2,
+      timeout: 1000,
+    }
+
+    const service = new LLMService(config, {
+      openAIFactory: () => createMockClient(mockCreate),
+    })
+
+    const promise = service.analyzeGameplay({
+      imageBuffer: Buffer.from('x'),
+      gameContext: 'ctx',
+      analysisType: 'tactical',
+    })
+
+    await vi.runAllTimersAsync()
+    const res = await promise
+    expect(res.advice).toBe('advice')
+    expect(mockCreate).toHaveBeenCalledTimes(3)
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- define `OpenAIClient`, `GeminiClient`, and `ScreenCaptureAPI` interfaces
- inject factories into `LLMService` and `GameDetectorService`
- update zustand stores to pass dependencies
- add unit tests for retry logic and detection behaviour

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840fe4b7f108326a194eca0ef1052e1