### PR TITLE
Inject external client interfaces

### DIFF
--- a/src/renderer/services/external-clients.ts
+++ b/src/renderer/services/external-clients.ts
@@ -1,0 +1,39 @@
+export interface OpenAIClient {
+  chat: {
+    completions: {
+      create: (params: any) => Promise<{ choices: { message: { content: string } }[] }>
+    }
+  }
+}
+
+export interface GeminiModel {
+  generateContent: (input: any[]) => Promise<{ response: { text(): string } }>
+}
+
+export interface GeminiClient {
+  getGenerativeModel: (options: { model: string }) => GeminiModel
+}
+
+import OpenAI from 'openai'
+import { GoogleGenerativeAI } from '@google/generative-ai'
+
+export const createDefaultOpenAIClient = (apiKey: string): OpenAIClient => {
+  return new OpenAI({ apiKey, dangerouslyAllowBrowser: true }) as OpenAIClient
+}
+
+export const createDefaultGeminiClient = (apiKey: string): GeminiClient => {
+  return new GoogleGenerativeAI(apiKey) as GeminiClient
+}
+
+export interface ScreenCaptureAPI {
+  getCaptureSource(): Promise<any[]>
+}
+
+export const defaultScreenCaptureAPI: ScreenCaptureAPI = {
+  async getCaptureSource() {
+    if (typeof window !== 'undefined' && (window as any).electronAPI && typeof (window as any).electronAPI.getCaptureSource === 'function') {
+      return (window as any).electronAPI.getCaptureSource()
+    }
+    return []
+  }
+}

--- a/tests/game-detector.test.ts
+++ b/tests/game-detector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { GameDetectorService } from '../src/renderer/services/game-detector'
+import type { ScreenCaptureAPI } from '../src/renderer/services/external-clients'
 
 describe('GameDetectorService', () => {
   it('findGameInSources returns matching source', () => {
@@ -9,5 +10,23 @@ describe('GameDetectorService', () => {
       { id: '2', name: 'Other' }
     ])
     expect(match?.id).toBe('1')
+  })
+
+  it('detectRavenswatch true when source found', async () => {
+    const api: ScreenCaptureAPI = {
+      getCaptureSource: vi.fn(async () => [{ id: '1', name: 'Ravenswatch' }])
+    }
+    const svc = new GameDetectorService(api)
+    const result = await (svc as any).detectRavenswatch()
+    expect(result.isGameRunning).toBe(true)
+  })
+
+  it('detectRavenswatch false when no source', async () => {
+    const api: ScreenCaptureAPI = {
+      getCaptureSource: vi.fn(async () => [{ id: '1', name: 'Other' }])
+    }
+    const svc = new GameDetectorService(api)
+    const result = await (svc as any).detectRavenswatch()
+    expect(result.isGameRunning).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- create external client interfaces for LLMs and screen capture
- refactor LLMService and GameDetectorService to accept injected clients
- provide default factories for real OpenAI, Gemini and capture API
- update tests for game detection

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68419a3bc2308326a2216c9a473e25d8