### PR TITLE
Add Playwright E2E test

### DIFF
--- a/docs/plans/e2e-testing-guide.md
+++ b/docs/plans/e2e-testing-guide.md
@@ -1,0 +1,65 @@
+# Electron End-to-End Testing Guide
+
+This guide explains how to run end-to-end (E2E) tests for the Ravenswatch Game Coach using [Playwright](https://playwright.dev/).
+Playwright can control the Electron process directly which allows interacting with the rendered UI just like a user.
+
+## 1. Install dependencies
+
+```bash
+npm install --save-dev @playwright/test playwright-electron
+```
+
+The `playwright-electron` package exposes an `_electron` launcher that starts the app with a full Electron context.
+
+## 2. Build the main process
+
+Playwright launches the compiled Electron app. Run the build step before executing the tests:
+
+```bash
+npm run build:electron
+```
+
+## 3. Example test script
+
+Create a file such as `tests/e2e/settings.test.ts`:
+
+```ts
+import { _electron as electron, expect, test } from '@playwright/test'
+
+// Starts the Electron app and verifies that changing a setting persists
+test('update settings from modal', async () => {
+  // Launch using the project root (relies on package.json "main")
+  const electronApp = await electron.launch({ args: ['.'] })
+
+  // Get the first BrowserWindow
+  const window = await electronApp.firstWindow()
+
+  // Open the Settings modal
+  await window.getByRole('button', { name: 'Settings' }).click()
+
+  // Toggle one of the checkboxes
+  await window.getByRole('checkbox', { name: 'Overlay Enabled' }).check()
+
+  // Expect the UI to reflect the change
+  await expect(window.getByRole('checkbox', { name: 'Overlay Enabled' })).toBeChecked()
+
+  // Close the app
+  await electronApp.close()
+})
+```
+
+## 4. Running the tests
+
+Add a script entry to `package.json`:
+
+```json
+"test:e2e": "playwright test"
+```
+
+Then execute:
+
+```bash
+npm run test:e2e
+```
+
+The Playwright runner will start an Electron instance, open the main window and execute the scripted interactions. This approach ensures that UI flows such as opening the Settings modal and updating preferences work correctly in a real Electron environment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "zustand": "^4.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -37,6 +38,7 @@
         "eslint-plugin-react": "^7.33.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "jsdom": "^26.1.0",
+        "playwright-electron": "^0.5.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^3.3.0",
         "ts-node": "^10.9.2",
@@ -2091,6 +2093,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -7893,6 +7911,13 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9242,6 +9267,100 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright-electron": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/playwright-electron/-/playwright-electron-0.5.0.tgz",
+      "integrity": "sha512-DHLV9D9DPJfXe1/nrq5DMkHzLcqOxII5M0Yi6BHy9dDlMjOshOa3C/WxSBvxZ7l7R/3bMRtOU3o1NCy8aueBaQ==",
+      "deprecated": "This package won't get updated anymore, please refer to the main Playwright package: https://playwright.dev/docs/api/class-electron",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "jpeg-js": "^0.4.2",
+        "mime": "^2.4.6",
+        "pngjs": "^5.0.0",
+        "progress": "^2.0.3",
+        "proper-lockfile": "^4.1.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "ws": "^7.3.1"
+      },
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/playwright-electron/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -9255,6 +9374,16 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -9526,6 +9655,25 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:electron": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"CommonJS\"}' xvfb-run -a npx electron-mocha --renderer --require ts-node/register --no-window tests/electron/**/*.ts --no-sandbox"
+    ,"test:e2e": "playwright test"
   },
   "dependencies": {
     "@google/generative-ai": "^0.2.0",
@@ -32,6 +33,7 @@
     "zustand": "^4.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
@@ -52,6 +54,7 @@
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jsdom": "^26.1.0",
+    "playwright-electron": "^0.5.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.3.0",
     "ts-node": "^10.9.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    headless: true,
+  },
+  timeout: 60_000,
+})

--- a/tests/e2e/settings.test.ts
+++ b/tests/e2e/settings.test.ts
@@ -1,0 +1,13 @@
+import { _electron as electron, expect, test } from '@playwright/test'
+
+// Launch the Electron app and open the settings modal
+test('open settings from main window', async () => {
+  const electronApp = await electron.launch({ args: ['.'] })
+
+  const window = await electronApp.firstWindow()
+  await window.getByRole('button', { name: 'Settings' }).click()
+
+  await expect(window.getByRole('heading', { name: 'Settings' })).toBeVisible()
+
+  await electronApp.close()
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    exclude: ['**/node_modules/**', 'tests/electron/**']
+    exclude: ['**/node_modules/**', 'tests/electron/**', 'tests/e2e/**']
   },
 })


### PR DESCRIPTION
## Summary
- set up Playwright config and dependencies
- add test:e2e npm script
- exclude e2e folder from Vitest
- implement starter e2e test opening Settings modal

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844645008808326bb259c9514da5c6c