### PR TITLE
Add e2e tests to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,4 @@ jobs:
       - run: npm run lint
       - run: npm run type-check
       - run: npm test
+      - run: npm run test:e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,10 @@
 ## Testing Requirements
 - **Always write tests** for any new code you introduce.
 - Before committing, run the following commands:
-  - `npm run lint`
-  - `npm run type-check`
-  - `npm test`
+    - `npm run lint`
+    - `npm run type-check`
+    - `npm test`
+    - `npm run test:e2e`
 
 ## Project Structure
 - Follow the directory and file organization described in `README.md`.


### PR DESCRIPTION
## Summary
- run Playwright e2e tests in CI
- document e2e test command in contribution guidelines

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:e2e` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_684471a0c5f48326ae51116bb4282eac