### PR TITLE
Add overlay e2e check

### DIFF
--- a/tests/e2e/settings.test.ts
+++ b/tests/e2e/settings.test.ts
@@ -1,13 +1,43 @@
 import { _electron as electron, expect, test } from '@playwright/test'
 
+// Utility to launch the app for each test
+const launchApp = () => electron.launch({ args: ['.', '--no-sandbox'] })
+
 // Launch the Electron app and open the settings modal
 test('open settings from main window', async () => {
-  const electronApp = await electron.launch({ args: ['.', '--no-sandbox'] })
+  const electronApp = await launchApp()
 
-  const window = await electronApp.firstWindow()
-  await window.getByRole('button', { name: 'Settings' }).click()
+  const page = await electronApp.firstWindow()
+  await page.getByRole('button', { name: 'Settings' }).click()
 
-  await expect(window.getByRole('heading', { name: 'Settings' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+
+  await electronApp.close()
+})
+
+test('overlay displays in top right by default', async () => {
+  const electronApp = await launchApp()
+
+  const page = await electronApp.firstWindow()
+
+  // Open settings and go to Overlay tab
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await page.getByRole('button', { name: 'Overlay', exact: true }).click()
+  await expect(page.getByText('Enable Overlay')).toBeVisible()
+
+  // Close settings modal
+  await page.getByRole('button', { name: 'Cancel' }).click()
+
+  // Show overlay
+  await page.getByRole('button', { name: 'Show Overlay' }).click()
+
+  // Wait for overlay window
+  const overlayPage = await electronApp.waitForEvent('window', win =>
+    win.url().includes('#overlay')
+  )
+  const position = await overlayPage.evaluate(() => ({ x: window.screenX, y: window.screenY }))
+  expect(position.y).toBe(20)
+  expect(position.x).toBeGreaterThan(0)
 
   await electronApp.close()
 })


### PR DESCRIPTION
## Summary
- ensure the overlay tab can be opened in the settings panel
- verify the overlay window appears in the top right corner by default

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6844c4ac13c083268951132524008046