### PR TITLE
Plan overlay panel refactor

### DIFF
--- a/docs/plans/overlay-settings-refactor-tasks.md
+++ b/docs/plans/overlay-settings-refactor-tasks.md
@@ -1,0 +1,20 @@
+# Overlay Settings Refactor Tasks
+
+These tasks cover the work for simplifying the settings panel by integrating all overlay testing controls into the `Overlay` tab and removing the separate `Testing` tab.
+
+## Refactor
+- [ ] Remove the `Testing` tab from `SettingsModal`.
+- [ ] Embed `OverlayTestSuite` directly under the overlay configuration options.
+- [ ] Ensure position, style and duration testers work when accessed from the `Overlay` tab.
+- [ ] Persist overlay testing values immediately when updated.
+
+## Testing
+- [ ] Update unit tests for `SettingsModal` to check that `OverlayTestSuite` renders when the overlay tab is active.
+- [ ] Update e2e test to open the `Overlay` tab and verify the presence of testing controls.
+
+## Verification
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run type-check`.
+- [ ] Run `npm test`.
+- [ ] Run `npm run test:e2e`.
+

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -29,7 +29,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
     error,
   } = useSyncGameCoachStore()
   const [localSettings, setLocalSettings] = useState(settings)
-  const [activeTab, setActiveTab] = useState<'api' | 'overlay' | 'instructions' | 'testing' | 'tts' | 'performance' | 'general'>('api')// Sync local settings when store settings change
+  const [activeTab, setActiveTab] = useState<'api' | 'overlay' | 'instructions' | 'tts' | 'performance' | 'general'>('api')
+  // Sync local settings when store settings change
   useEffect(() => {
     setLocalSettings(settings)
   }, [settings])
@@ -86,7 +87,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
             { id: 'api', label: 'API Keys' },
             { id: 'overlay', label: 'Overlay' },
             { id: 'instructions', label: 'Instructions' },
-            { id: 'testing', label: 'Testing' },
             { id: 'tts', label: 'Text-to-Speech' },
             { id: 'performance', label: 'Performance' },
             { id: 'general', label: 'General' },
@@ -264,21 +264,20 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                   className="w-full bg-gray-700 border border-gray-600 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-primary-500"
                 />
                 <p className="text-xs text-gray-400 mt-1">
-                  Minimum time between advice suggestions                </p>
+                  Minimum time between advice suggestions
+                </p>
               </div>
-            </div>          )}          {/* Instructions Tab */}
+
+              <OverlayTestSuite />
+            </div>
+          )}
+          {/* Instructions Tab */}
           {activeTab === 'instructions' && (
             <div className="h-96 overflow-y-auto p-2">
               <InstructionTemplate />
             </div>
           )}
 
-          {/* Testing Tab */}
-          {activeTab === 'testing' && (
-            <div className="h-96 overflow-y-auto">
-              <OverlayTestSuite />
-            </div>
-          )}
 
           {/* TTS Tab */}
           {activeTab === 'tts' && (

--- a/tests/SettingsModal.test.tsx
+++ b/tests/SettingsModal.test.tsx
@@ -70,4 +70,20 @@ describe('SettingsModal component', () => {
     fireEvent.click(screen.getAllByText('Cancel')[0])
     expect(setSettingsModalOpen).toHaveBeenCalledWith(false)
   })
+
+  it('renders overlay testing suite within overlay tab', () => {
+    mockUseStore.mockReturnValue({
+      settings,
+      updateSettings: vi.fn(),
+      isSettingsModalOpen: true,
+      setSettingsModalOpen: vi.fn(),
+      isLoading: false,
+      error: null
+    })
+
+    render(<SettingsModal />)
+
+    fireEvent.click(screen.getByText('Overlay'))
+    expect(screen.getByText('OverlayTestSuite')).toBeInTheDocument()
+  })
 })

--- a/tests/e2e/settings.test.ts
+++ b/tests/e2e/settings.test.ts
@@ -41,3 +41,15 @@ test('overlay displays in top right by default', async () => {
 
   await electronApp.close()
 })
+
+test('overlay tab shows overlay testing controls', async () => {
+  const electronApp = await launchApp()
+
+  const page = await electronApp.firstWindow()
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await page.getByRole('button', { name: 'Overlay', exact: true }).click()
+
+  await expect(page.getByText('Overlay Testing Suite')).toBeVisible()
+
+  await electronApp.close()
+})


### PR DESCRIPTION
## Summary
- add tasks for overlay settings refactor
- integrate overlay testing controls directly in the Overlay tab
- update SettingsModal unit test
- update e2e test to look for overlay testing suite

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:e2e` *(fails: xvfb-run not found)*


------
https://chatgpt.com/codex/tasks/task_e_6844c8ef9f288326924b0342fa9ef05b