### PR TITLE
Move overlay control to settings modal

### DIFF
--- a/src/renderer/components/ConfigPanel.tsx
+++ b/src/renderer/components/ConfigPanel.tsx
@@ -24,13 +24,7 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({
     initializeLLMService,
     setAnalyzing,
     gameState,
-    isOverlayVisible,
-    showOverlay,
-    hideOverlay,
-    updateSettings,
-    setGameDetection,
-    setGameState,
-    setLastAnalysis,    selectedSourceId,
+    selectedSourceId,
     setSelectedSource,
     llmService,
   } = useSyncGameCoachStore()// Screen sources state
@@ -122,134 +116,6 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({
     }
   }
 
-  const handleToggleOverlay = async () => {
-    if (isOverlayVisible) {
-      await hideOverlay()
-    } else {
-      await showOverlay()
-    }
-  }
-  const handleTestAdvice = () => {
-    // Simulate advice for testing
-    const testAnalysis = {
-      advice: "Test advice: Focus on dodging enemy attacks and look for openings to counter-attack.",
-      confidence: 0.85,
-      provider: 'test',
-      analysisTime: 120,
-      timestamp: Date.now(),
-      category: 'combat' as const
-    }
-      // Update the store with test analysis
-    setLastAnalysis(testAnalysis)
-    console.log('ConfigPanel: Test advice triggered:', testAnalysis)
-  }
-
-  const handleTestAutomaticFlow = async () => {
-    console.log('ConfigPanel: Testing automatic overlay flow...')
-    
-    try {
-      // Step 1: Ensure overlay is enabled
-      if (!settings.overlayEnabled) {
-        console.log('ConfigPanel: Enabling overlay in settings...')
-        updateSettings({ overlayEnabled: true })
-        await new Promise(resolve => setTimeout(resolve, 500))
-      }
-      
-      // Step 2: Show overlay manually first to verify it works
-      console.log('ConfigPanel: Testing manual overlay show...')
-      await showOverlay()
-      
-      // Step 3: Simulate game detection with overlay auto-show
-      console.log('ConfigPanel: Simulating game detection...')
-      
-      // Temporarily simulate a positive detection
-      const mockDetection = {
-        isGameRunning: true,
-        confidence: 0.9,
-        detectionMethod: 'test',
-        gameWindow: {
-          id: 'test',
-          name: 'Test Ravenswatch',
-          executable: 'ravenswatch.exe',
-          isActive: true
-        }
-      }
-        // Trigger the same logic as real detection
-      setGameDetection(mockDetection)
-      setGameState({ isRavenswatchDetected: true })
-      
-      // Test analysis trigger
-      setTimeout(() => {
-        console.log('ConfigPanel: Testing analysis trigger...')
-        setAnalyzing(true)
-      }, 2000)
-      
-      console.log('ConfigPanel: Automatic flow test complete')
-    } catch (error) {
-      console.error('ConfigPanel: Automatic flow test failed:', error)
-    }
-  }
-
-  const handleForceContent = async () => {
-    console.log('ConfigPanel: Force Content button clicked - triggering all overlay states...')
-    
-    try {
-      // Step 1: Ensure overlay is enabled and visible
-      if (!settings.overlayEnabled) {
-        console.log('ConfigPanel: Enabling overlay in settings...')
-        updateSettings({ overlayEnabled: true })
-        await new Promise(resolve => setTimeout(resolve, 500))
-      }
-      
-      // Step 2: Show overlay
-      console.log('ConfigPanel: Showing overlay...')
-      await showOverlay()
-      await new Promise(resolve => setTimeout(resolve, 1000))
-      
-      // Step 3: Set all states that should make content visible
-      console.log('ConfigPanel: Setting game detection state...')
-      const mockDetection = {
-        isGameRunning: true,
-        confidence: 0.95,
-        detectionMethod: 'forced-test',
-        gameWindow: {
-          id: 'test-force',
-          name: 'Test Ravenswatch (Forced)',
-          executable: 'ravenswatch.exe',
-          isActive: true
-        }
-      }
-        setGameDetection(mockDetection)
-      setGameState({ isRavenswatchDetected: true })
-      
-      // Step 4: Trigger analysis state
-      console.log('ConfigPanel: Setting analysis state...')
-      setAnalyzing(true)
-      
-      // Step 5: Add test advice to make sure all content is visible
-      console.log('ConfigPanel: Adding test advice...')
-      const testAnalysis = {
-        advice: "🎯 FORCE CONTENT TEST: This advice should be visible in the overlay! The system is working correctly if you can see this message along with all the colorful debug panels.",
-        confidence: 0.95,
-        provider: 'force-test',
-        analysisTime: 50,
-        timestamp: Date.now(),
-        category: 'test' as const
-      }
-        setLastAnalysis(testAnalysis)
-      
-      console.log('ConfigPanel: Force Content complete - overlay should now show all content!')
-      console.log('ConfigPanel: Check the overlay window for:')
-      console.log('  - Blue test panel (top-right)')
-      console.log('  - Red test element (top-left)')
-      console.log('  - Green test element (bottom-right)')
-      console.log('  - Test advice message')
-      console.log('  - Status indicators with emojis')
-      
-    } catch (error) {
-      console.error('ConfigPanel: Force Content failed:', error)
-    }
-  }
   const isProviderConfigured = settings.llmProvider === 'openai' 
     ? !!settings.openaiApiKey 
     : !!settings.geminiApiKey
@@ -483,63 +349,8 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({
             Initializing AI service...
           </p>
         )}
-      </div>{/* Overlay Control */}
-      <div className="bg-gray-700 rounded-lg p-4">
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-sm font-medium text-gray-300">Overlay Control</h3>
-          <div className="flex items-center space-x-2">
-            <span className={`w-2 h-2 rounded-full ${
-              isOverlayVisible ? 'bg-green-400' : 'bg-gray-500'
-            }`}></span>
-            <span className="text-xs text-gray-400">
-              {isOverlayVisible ? 'Visible' : 'Hidden'}
-            </span>
-          </div>
-        </div>
-
-        <div className="space-y-2 text-xs text-gray-400 mb-3">
-          <div>Status: <span className={isOverlayVisible ? 'text-green-300' : 'text-red-300'}>
-            {isOverlayVisible ? 'Active' : 'Inactive'}
-          </span></div>
-          <div>Enabled in Settings: <span className={settings.overlayEnabled ? 'text-green-300' : 'text-red-300'}>
-            {settings.overlayEnabled ? 'Yes' : 'No'}
-          </span></div>
-          <div>Theme: <span className="text-white capitalize">{settings.overlayTheme}</span></div>
-          <div>Size: <span className="text-white capitalize">{settings.overlaySize}</span></div>
-        </div>
-
-        <button
-          onClick={handleToggleOverlay}
-          disabled={!settings.overlayEnabled}
-          className={isOverlayVisible ? 'btn-danger text-xs' : 'btn-primary text-xs'}
-        >
-          {isOverlayVisible ? 'Hide Overlay' : 'Show Overlay'}
-        </button>        {isOverlayVisible && (
-          <button
-            onClick={handleTestAdvice}
-            className="btn-secondary text-xs ml-2"
-          >
-            Test Advice
-          </button>
-        )}        <button
-          onClick={handleTestAutomaticFlow}
-          className="btn-secondary text-xs ml-2"
-        >
-          Test Auto Flow
-        </button>
-
-        <button
-          onClick={handleForceContent}
-          className="bg-purple-600 hover:bg-purple-700 text-white px-3 py-1 rounded text-xs ml-2"
-        >
-          Force Content
-        </button>
-
-        {!settings.overlayEnabled && (
-          <p className="text-xs text-yellow-300 mt-2">
-            Enable overlay in settings first
-          </p>
-        )}      </div>      {/* Latest Analysis */}
+      </div>
+      {/* Latest Analysis */}
       {lastAnalysis && (
         <div className="bg-gray-700 rounded-lg p-4">
           <h3 className="text-sm font-medium text-gray-300 mb-3">Latest Analysis</h3>

--- a/tests/ConfigPanel.test.tsx
+++ b/tests/ConfigPanel.test.tsx
@@ -14,8 +14,8 @@ beforeAll(() => {
 })
 
 describe('ConfigPanel component', () => {
-  it('calls showOverlay when button clicked', () => {
-    const showOverlay = vi.fn()
+  it('opens settings modal when settings button clicked', () => {
+    const setSettingsModalOpen = vi.fn()
     const client: ScreenSourceClient = {
       getCaptureSources: vi.fn().mockResolvedValue([]),
     }
@@ -27,17 +27,10 @@ describe('ConfigPanel component', () => {
       error: null,
       startGameDetection: vi.fn(),
       stopGameDetection: vi.fn(),
-      setSettingsModalOpen: vi.fn(),
+      setSettingsModalOpen,
       initializeLLMService: vi.fn(),
       setAnalyzing: vi.fn(),
       gameState: { isRavenswatchDetected: false },
-      isOverlayVisible: false,
-      showOverlay,
-      hideOverlay: vi.fn(),
-      updateSettings: vi.fn(),
-      setGameDetection: vi.fn(),
-      setGameState: vi.fn(),
-      setLastAnalysis: vi.fn(),
       selectedSourceId: '1',
       setSelectedSource: vi.fn(),
       llmService: null,
@@ -45,8 +38,8 @@ describe('ConfigPanel component', () => {
 
     render(<ConfigPanel screenSourceClient={client} />)
 
-    const btn = screen.getByText('Show Overlay')
+    const btn = screen.getByText('Settings')
     fireEvent.click(btn)
-    expect(showOverlay).toHaveBeenCalled()
+    expect(setSettingsModalOpen).toHaveBeenCalledWith(true)
   })
 })

--- a/tests/SettingsModal.test.tsx
+++ b/tests/SettingsModal.test.tsx
@@ -86,4 +86,29 @@ describe('SettingsModal component', () => {
     fireEvent.click(screen.getByText('Overlay'))
     expect(screen.getByText('OverlayTestSuite')).toBeInTheDocument()
   })
+
+  it('calls showOverlay when overlay control button clicked', () => {
+    const showOverlay = vi.fn()
+    mockUseStore.mockReturnValue({
+      settings,
+      updateSettings: vi.fn(),
+      isSettingsModalOpen: true,
+      setSettingsModalOpen: vi.fn(),
+      isLoading: false,
+      error: null,
+      isOverlayVisible: false,
+      showOverlay,
+      hideOverlay: vi.fn(),
+      setGameDetection: vi.fn(),
+      setGameState: vi.fn(),
+      setLastAnalysis: vi.fn(),
+      setAnalyzing: vi.fn(),
+    })
+
+    render(<SettingsModal />)
+
+    fireEvent.click(screen.getByText('Overlay'))
+    fireEvent.click(screen.getByText('Show Overlay'))
+    expect(showOverlay).toHaveBeenCalled()
+  })
 })

--- a/tests/e2e/settings.test.ts
+++ b/tests/e2e/settings.test.ts
@@ -25,10 +25,7 @@ test('overlay displays in top right by default', async () => {
   await page.getByRole('button', { name: 'Overlay', exact: true }).click()
   await expect(page.getByText('Enable Overlay')).toBeVisible()
 
-  // Close settings modal
-  await page.getByRole('button', { name: 'Cancel' }).click()
-
-  // Show overlay
+  // Show overlay from overlay tab
   await page.getByRole('button', { name: 'Show Overlay' }).click()
 
   // Wait for overlay window


### PR DESCRIPTION
## Summary
- relocate overlay control into settings modal under Overlay tab
- adjust ConfigPanel to remove overlay controls
- update unit and e2e tests for new location

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6844d1ed33188326bb5e8cf45caa5012