### PR TITLE
Improve overlay position preview

### DIFF
--- a/src/main/state-manager.ts
+++ b/src/main/state-manager.ts
@@ -52,7 +52,7 @@ export class StateManager {
         overlayEnabled: true,
         ttsEnabled: false,
         adviceFrequency: 5,
-        overlayPosition: { x: 90, y: 10 },
+        overlayPosition: { x: 85, y: 11 },
         ttsVoice: 'default',
         ttsSpeed: 1.0,
         ttsVolume: 0.8,        ttsOnlyUrgent: false,

--- a/src/main/state-manager.ts
+++ b/src/main/state-manager.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain } from 'electron'
+import { BrowserWindow, ipcMain, screen } from 'electron'
 import type { SettingsStorage } from './settings-storage'
 import { defaultSettingsStorage } from './settings-storage'
 import type {
@@ -52,7 +52,7 @@ export class StateManager {
         overlayEnabled: true,
         ttsEnabled: false,
         adviceFrequency: 5,
-        overlayPosition: { x: 20, y: 20 },
+        overlayPosition: { x: 90, y: 10 },
         ttsVoice: 'default',
         ttsSpeed: 1.0,
         ttsVolume: 0.8,        ttsOnlyUrgent: false,
@@ -186,6 +186,17 @@ export class StateManager {
     console.log('StateManager: Setting settings:', Object.keys(settings))
     this.state.settings = { ...this.state.settings, ...settings }
     this.broadcastStateUpdate()
+
+    if (settings.overlayPosition && this.overlayWindow) {
+      const { width, height } = screen.getPrimaryDisplay().workAreaSize
+      const bounds = this.overlayWindow.getBounds()
+      const { x, y } = this.state.settings.overlayPosition
+      const centerX = (width * x) / 100
+      const centerY = (height * y) / 100
+      const posX = Math.max(0, Math.min(width - bounds.width, Math.round(centerX - bounds.width / 2)))
+      const posY = Math.max(0, Math.min(height - bounds.height, Math.round(centerY - bounds.height / 2)))
+      this.overlayWindow.setBounds({ x: posX, y: posY })
+    }
     
     // Auto-save settings to disk
     this.saveSettingsToDisk().catch(error => {

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -47,17 +47,36 @@ export class WindowManager {
     return this.mainWindow
   }
 
+  private calculateOverlayPosition(overlayWidth: number, overlayHeight: number) {
+    const { width, height } = screen.getPrimaryDisplay().workAreaSize
+    const { x, y } = this.stateManager.getSettings().overlayPosition
+    const centerX = (width * x) / 100
+    const centerY = (height * y) / 100
+    const posX = Math.max(0, Math.min(width - overlayWidth, Math.round(centerX - overlayWidth / 2)))
+    const posY = Math.max(0, Math.min(height - overlayHeight, Math.round(centerY - overlayHeight / 2)))
+    return { x: posX, y: posY }
+  }
+
+  private moveOverlayWindow() {
+    if (!this.overlayWindow) return
+    const { width, height } = this.overlayWindow.getBounds()
+    const { x, y } = this.calculateOverlayPosition(width, height)
+    this.overlayWindow.setBounds({ x, y })
+  }
+
   createOverlayWindow(): ElectronBrowserWindow {
     if (this.overlayWindow) {
+      this.moveOverlayWindow()
       this.overlayWindow.focus()
       return this.overlayWindow
     }
 
-    const { width } = screen.getPrimaryDisplay().workAreaSize
     const overlayWidth = 300
     const overlayHeight = 150
-    const overlayX = Math.max(0, width - overlayWidth - 20)
-    const overlayY = 20
+    const { x: overlayX, y: overlayY } = this.calculateOverlayPosition(
+      overlayWidth,
+      overlayHeight
+    )
 
     const opts: BrowserWindowConstructorOptions = {
       width: overlayWidth,

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -71,8 +71,8 @@ export class WindowManager {
       return this.overlayWindow
     }
 
-    const overlayWidth = 540
-    const overlayHeight = 200
+    const overlayWidth = 640
+    const overlayHeight = 240
     const { x: overlayX, y: overlayY } = this.calculateOverlayPosition(
       overlayWidth,
       overlayHeight

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -71,8 +71,8 @@ export class WindowManager {
       return this.overlayWindow
     }
 
-    const overlayWidth = 300
-    const overlayHeight = 150
+    const overlayWidth = 540
+    const overlayHeight = 200
     const { x: overlayX, y: overlayY } = this.calculateOverlayPosition(
       overlayWidth,
       overlayHeight

--- a/src/renderer/components/GameOverlay.tsx
+++ b/src/renderer/components/GameOverlay.tsx
@@ -25,7 +25,7 @@ const themeStyles = {
 const sizeStyles = {
   small: 'max-w-xs text-xs p-3',
   medium: 'max-w-sm text-sm p-4',
-  large: 'max-w-md text-base p-5'
+  large: 'max-w-lg text-base p-6'
 }
 
 const GameOverlay: React.FC = () => {

--- a/src/renderer/components/GameOverlay.tsx
+++ b/src/renderer/components/GameOverlay.tsx
@@ -65,11 +65,12 @@ const GameOverlay: React.FC = () => {
     >
       {/* Advice Display */}
       {showAdvice && currentAdvice && (
-        <div 
+        <div
           className={`absolute animate-slideInRight ${sizeClass}`}
           style={{
-            top: settings.overlayPosition.y,
-            right: 20
+            top: `${settings.overlayPosition.y}%`,
+            left: `${settings.overlayPosition.x}%`,
+            transform: 'translate(-50%, -50%)'
           }}
         >
           <div className={`${theme.background} rounded-lg shadow-2xl transition-all duration-300`}>

--- a/src/renderer/components/GameOverlay.tsx
+++ b/src/renderer/components/GameOverlay.tsx
@@ -61,7 +61,9 @@ const GameOverlay: React.FC = () => {
   const adviceDisplay =
     showAdvice && currentAdvice ? (
       <div className={`animate-slideInRight ${sizeClass}`}>
-        <div className={`${theme.background} rounded-lg shadow-2xl transition-all duration-300`}>
+        <div
+          className={`${theme.background} rounded-lg shadow-2xl transition-all duration-300 p-4`}
+        >
           <div className="flex items-start space-x-3">
             <div className={`w-2 h-2 ${theme.indicator} rounded-full mt-2 flex-shrink-0 animate-pulse`} />
             <div className="flex-1">

--- a/src/renderer/components/GameOverlay.tsx
+++ b/src/renderer/components/GameOverlay.tsx
@@ -68,8 +68,8 @@ const GameOverlay: React.FC = () => {
         <div
           className={`absolute animate-slideInRight ${sizeClass}`}
           style={{
-            top: `${settings.overlayPosition.y}%`,
-            left: `${settings.overlayPosition.x}%`,
+            top: '50%',
+            left: '50%',
             transform: 'translate(-50%, -50%)'
           }}
         >

--- a/src/renderer/components/GameOverlay.tsx
+++ b/src/renderer/components/GameOverlay.tsx
@@ -25,7 +25,7 @@ const themeStyles = {
 const sizeStyles = {
   small: 'max-w-xs text-xs p-3',
   medium: 'max-w-sm text-sm p-4',
-  large: 'max-w-lg text-base p-6'
+  large: 'max-w-xl text-base p-6'
 }
 
 const GameOverlay: React.FC = () => {
@@ -58,86 +58,94 @@ const GameOverlay: React.FC = () => {
   const theme = themeStyles[settings.overlayTheme] || themeStyles.dark
   const sizeClass = sizeStyles[settings.overlaySize] || sizeStyles.large
 
-  return (
-    <div 
-      className="fixed inset-0 pointer-events-none z-50"
-      style={{ opacity: settings.overlayOpacity }}
-    >
-      {/* Advice Display */}
-      {showAdvice && currentAdvice && (
-        <div
-          className={`absolute animate-slideInRight ${sizeClass}`}
-          style={{
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)'
-          }}
-        >
-          <div className={`${theme.background} rounded-lg shadow-2xl transition-all duration-300`}>
-            <div className="flex items-start space-x-3">
-              <div className={`w-2 h-2 ${theme.indicator} rounded-full mt-2 flex-shrink-0 animate-pulse`} />
-              <div className="flex-1">
-                <div className="flex items-center justify-between mb-2">
-                  <p className={`${theme.accent} font-medium`}>AI Coach</p>
-                  {lastAnalysis && settings.showConfidenceScore && (
-                    <div className="flex items-center space-x-2">
-                      <span className="text-xs text-gray-400">
-                        {(lastAnalysis.confidence * 100).toFixed(0)}%
-                      </span>
-                      <div className="w-8 h-1 bg-gray-600 rounded">
-                        <div 
-                          className="h-1 bg-green-400 rounded transition-all duration-300"
-                          style={{ width: `${lastAnalysis.confidence * 100}%` }}
-                        />
-                      </div>
+  const adviceDisplay =
+    showAdvice && currentAdvice ? (
+      <div className={`animate-slideInRight ${sizeClass}`}>
+        <div className={`${theme.background} rounded-lg shadow-2xl transition-all duration-300`}>
+          <div className="flex items-start space-x-3">
+            <div className={`w-2 h-2 ${theme.indicator} rounded-full mt-2 flex-shrink-0 animate-pulse`} />
+            <div className="flex-1">
+              <div className="flex items-center justify-between mb-2">
+                <p className={`${theme.accent} font-medium`}>AI Coach</p>
+                {lastAnalysis && settings.showConfidenceScore && (
+                  <div className="flex items-center space-x-2">
+                    <span className="text-xs text-gray-400">
+                      {(lastAnalysis.confidence * 100).toFixed(0)}%
+                    </span>
+                    <div className="w-8 h-1 bg-gray-600 rounded">
+                      <div
+                        className="h-1 bg-green-400 rounded transition-all duration-300"
+                        style={{ width: `${lastAnalysis.confidence * 100}%` }}
+                      />
                     </div>
-                  )}
-                </div>
-                <p className={`${theme.text} leading-relaxed`}>
-                  {currentAdvice}
-                </p>
-                <div className="mt-2 flex items-center justify-between">
-                  <span className="text-xs text-gray-500">
-                    {lastAnalysis?.provider} • {lastAnalysis?.analysisTime}ms
-                  </span>
-                  <button
-                    onClick={() => setShowAdvice(false)}
-                    className="text-gray-400 hover:text-white transition-colors pointer-events-auto"
-                  >
-                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  </button>
-                </div>
+                  </div>
+                )}
+              </div>
+              <p className={`${theme.text} leading-relaxed`}>{currentAdvice}</p>
+              <div className="mt-2 flex items-center justify-between">
+                <span className="text-xs text-gray-500">
+                  {lastAnalysis?.provider} • {lastAnalysis?.analysisTime}ms
+                </span>
+                <button
+                  onClick={() => setShowAdvice(false)}
+                  className="text-gray-400 hover:text-white transition-colors pointer-events-auto"
+                >
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>
         </div>
-      )}
+      </div>
+    ) : null
 
-      {/* Status Indicators */}
-      <div className="absolute top-4 left-4 space-y-2">
-        {/* Game Detection Status */}
-        <div className={`${theme.background} rounded-full px-3 py-1 flex items-center space-x-2`}>
-          <div className={`w-2 h-2 rounded-full ${
+  const statusDisplay = (
+    <div className="flex flex-col items-center space-y-2">
+      <div className={`${theme.background} rounded-full px-3 py-1 flex items-center space-x-2`}>
+        <div
+          className={`w-2 h-2 rounded-full ${
             gameDetection?.isGameRunning ? 'bg-green-400 animate-pulse' : 'bg-red-400'
-          }`} />
+          }`}
+        />
+        <span className={`${theme.text} text-xs font-medium`}>
+          {gameDetection?.isGameRunning ? 'Ravenswatch Detected' : 'Game Not Detected'}
+        </span>
+      </div>
+      {gameDetection?.isGameRunning && (
+        <div className={`${theme.background} rounded-full px-3 py-1 flex items-center space-x-2`}>
+          <div
+            className={`w-2 h-2 rounded-full ${
+              isAnalyzing ? 'bg-blue-400 animate-pulse' : 'bg-gray-400'
+            }`}
+          />
           <span className={`${theme.text} text-xs font-medium`}>
-            {gameDetection?.isGameRunning ? 'Ravenswatch Detected' : 'Game Not Detected'}
+            {isAnalyzing ? 'AI Analyzing' : 'AI Idle'}
           </span>
         </div>
-        {/* AI Analysis Status */}
-        {gameDetection?.isGameRunning && (
-          <div className={`${theme.background} rounded-full px-3 py-1 flex items-center space-x-2`}>
-            <div className={`w-2 h-2 rounded-full ${
-              isAnalyzing ? 'bg-blue-400 animate-pulse' : 'bg-gray-400'
-            }`} />
-            <span className={`${theme.text} text-xs font-medium`}>
-              {isAnalyzing ? 'AI Analyzing' : 'AI Idle'}
-            </span>
-          </div>
-        )}
-      </div>
+      )}
+    </div>
+  )
+
+  const isBottom = settings.overlayPosition.y > 50
+
+  return (
+    <div
+      className="fixed inset-0 pointer-events-none z-50 flex flex-col items-center justify-center space-y-2"
+      style={{ opacity: settings.overlayOpacity }}
+    >
+      {isBottom ? (
+        <>
+          {adviceDisplay}
+          {statusDisplay}
+        </>
+      ) : (
+        <>
+          {statusDisplay}
+          {adviceDisplay}
+        </>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -80,6 +80,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   }
 
   const handleTestAdvice = () => {
+    const originalSize = settings.overlaySize
+    if (originalSize !== 'large') {
+      updateSettings({ overlaySize: 'large' })
+    }
     const testAnalysis = {
       advice:
         'Test advice: Focus on dodging enemy attacks and look for openings to counter-attack.',
@@ -90,6 +94,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
       category: 'combat' as const,
     }
     setLastAnalysis(testAnalysis)
+    if (originalSize !== 'large') {
+      setTimeout(() => {
+        updateSettings({ overlaySize: originalSize })
+      }, settings.autoHideDelay * 1000 + 500)
+    }
   }
 
   const handleTestAutomaticFlow = async () => {

--- a/src/renderer/stores/sync-store.ts
+++ b/src/renderer/stores/sync-store.ts
@@ -114,7 +114,7 @@ export function createSyncGameCoachStore(client: StateClient = new ElectronState
       overlayEnabled: true,
       ttsEnabled: false,
       adviceFrequency: 5,
-      overlayPosition: { x: 20, y: 20 },
+      overlayPosition: { x: 90, y: 10 },
       ttsVoice: 'default',
       ttsSpeed: 1.0,
       ttsVolume: 0.8,

--- a/src/renderer/stores/sync-store.ts
+++ b/src/renderer/stores/sync-store.ts
@@ -114,7 +114,7 @@ export function createSyncGameCoachStore(client: StateClient = new ElectronState
       overlayEnabled: true,
       ttsEnabled: false,
       adviceFrequency: 5,
-      overlayPosition: { x: 90, y: 10 },
+      overlayPosition: { x: 85, y: 11 },
       ttsVoice: 'default',
       ttsSpeed: 1.0,
       ttsVolume: 0.8,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -13,6 +13,8 @@ export interface AppSettings {
   overlayEnabled: boolean
   ttsEnabled: boolean
   adviceFrequency: number // seconds between advice
+  // Overlay position as percentages of the screen
+  // (0 = top/left, 100 = bottom/right)
   overlayPosition: {
     x: number
     y: number

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -14,7 +14,7 @@ export interface AppSettings {
   ttsEnabled: boolean
   adviceFrequency: number // seconds between advice
   // Overlay position as percentages of the screen
-  // (0 = top/left, 100 = bottom/right)
+  // Values represent the center of the overlay (0 = top/left, 100 = bottom/right)
   overlayPosition: {
     x: number
     y: number

--- a/tests/GameOverlayPosition.test.tsx
+++ b/tests/GameOverlayPosition.test.tsx
@@ -19,17 +19,17 @@ const baseSettings = {
 }
 
 describe('GameOverlay positioning', () => {
-  it('applies overlayPosition.y to overlay style', () => {
+  it('applies overlayPosition to overlay style', () => {
     mockUseStore.mockReturnValue({
       isOverlayVisible: true,
       lastAnalysis: { advice: 'test', confidence: 0.9, provider: 'test', analysisTime: 10 },
       isAnalyzing: false,
       gameDetection: { isGameRunning: true },
-      settings: { ...baseSettings, overlayPosition: { x: 0, y: 100 } }
+      settings: { ...baseSettings, overlayPosition: { x: 25, y: 75 } }
     })
 
     const { container } = render(<GameOverlay />)
     const overlay = container.querySelector('.animate-slideInRight') as HTMLElement
-    expect(overlay).toHaveStyle('top: 100px')
+    expect(overlay).toHaveStyle({ top: '75%', left: '25%' })
   })
 })

--- a/tests/GameOverlayPosition.test.tsx
+++ b/tests/GameOverlayPosition.test.tsx
@@ -19,7 +19,7 @@ const baseSettings = {
 }
 
 describe('GameOverlay positioning', () => {
-  it('applies overlayPosition to overlay style', () => {
+  it('centers overlay content within the window', () => {
     mockUseStore.mockReturnValue({
       isOverlayVisible: true,
       lastAnalysis: { advice: 'test', confidence: 0.9, provider: 'test', analysisTime: 10 },
@@ -30,6 +30,6 @@ describe('GameOverlay positioning', () => {
 
     const { container } = render(<GameOverlay />)
     const overlay = container.querySelector('.animate-slideInRight') as HTMLElement
-    expect(overlay).toHaveStyle({ top: '75%', left: '25%' })
+    expect(overlay).toHaveStyle({ top: '50%', left: '50%' })
   })
 })

--- a/tests/GameOverlayPosition.test.tsx
+++ b/tests/GameOverlayPosition.test.tsx
@@ -29,7 +29,9 @@ describe('GameOverlay positioning', () => {
     })
 
     const { container } = render(<GameOverlay />)
-    const overlay = container.querySelector('.animate-slideInRight') as HTMLElement
-    expect(overlay).toHaveStyle({ top: '50%', left: '50%' })
+    const root = container.firstChild as HTMLElement
+    expect(root).toHaveClass('flex')
+    expect(root).toHaveClass('items-center')
+    expect(root).toHaveClass('justify-center')
   })
 })

--- a/tests/e2e/settings.test.ts
+++ b/tests/e2e/settings.test.ts
@@ -32,9 +32,20 @@ test('overlay displays in top right by default', async () => {
   const overlayPage = await electronApp.waitForEvent('window', win =>
     win.url().includes('#overlay')
   )
-  const position = await overlayPage.evaluate(() => ({ x: window.screenX, y: window.screenY }))
-  expect(position.y).toBe(20)
-  expect(position.x).toBeGreaterThan(0)
+  const info = await overlayPage.evaluate(() => ({
+    x: window.screenX,
+    y: window.screenY,
+    w: window.outerWidth,
+    h: window.outerHeight,
+    sw: window.screen.width,
+    sh: window.screen.height,
+  }))
+  const expectedX = Math.round(info.sw * 0.9 - info.w / 2)
+  const expectedY = Math.round(info.sh * 0.1 - info.h / 2)
+  const clampedX = Math.max(0, Math.min(info.sw - info.w, expectedX))
+  const clampedY = Math.max(0, Math.min(info.sh - info.h, expectedY))
+  expect(info.x).toBe(clampedX)
+  expect(info.y).toBe(clampedY)
 
   await electronApp.close()
 })

--- a/tests/e2e/settings.test.ts
+++ b/tests/e2e/settings.test.ts
@@ -40,8 +40,8 @@ test('overlay displays in top right by default', async () => {
     sw: window.screen.width,
     sh: window.screen.height,
   }))
-  const expectedX = Math.round(info.sw * 0.9 - info.w / 2)
-  const expectedY = Math.round(info.sh * 0.1 - info.h / 2)
+  const expectedX = Math.round(info.sw * 0.85 - info.w / 2)
+  const expectedY = Math.round(info.sh * 0.11 - info.h / 2)
   const clampedX = Math.max(0, Math.min(info.sw - info.w, expectedX))
   const clampedY = Math.max(0, Math.min(info.sh - info.h, expectedY))
   expect(info.x).toBe(clampedX)


### PR DESCRIPTION
## Summary
- preview overlay in realtime when moving position
- temporarily enlarge overlay during advice testing
- update overlay positioning to use percentage coordinates
- adjust test suite for updated behavior

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6844dafba6f48326bca1d0fe87bb445c