### PR TITLE
Remove OpenAI integration

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -34,8 +34,7 @@ export function setupIPCHandlers() {
     } catch (error) {
       // Return default settings if file doesn't exist
       return {
-        llmProvider: 'openai',
-        openaiApiKey: '',
+        llmProvider: 'gemini',
         geminiApiKey: '',
         overlayEnabled: true,
         ttsEnabled: false,

--- a/src/main/state-manager.ts
+++ b/src/main/state-manager.ts
@@ -46,8 +46,7 @@ export class StateManager {
       },
       isAnalyzing: false,
       lastAnalysis: null,      settings: {
-        llmProvider: 'openai',
-        openaiApiKey: '',
+        llmProvider: 'gemini',
         geminiApiKey: '',
         overlayEnabled: true,
         ttsEnabled: false,

--- a/src/renderer/components/AnalysisEngine.tsx
+++ b/src/renderer/components/AnalysisEngine.tsx
@@ -235,7 +235,7 @@ export const AnalysisEngine: React.FC<AnalysisEngineProps> = ({
         content: result.advice,
         timestamp: result.timestamp,
         confidence: result.confidence,
-        provider: result.provider as 'openai' | 'gemini',
+        provider: result.provider as 'gemini',
         analysisTime: result.analysisTime,
       })
 
@@ -362,10 +362,9 @@ export const AnalysisEngine: React.FC<AnalysisEngineProps> = ({
   // Initialize LLM service when settings change
   useEffect(() => {
     console.log('AnalysisEngine: Settings changed, checking LLM initialization...')
-    console.log('AnalysisEngine: OpenAI key present:', !!settings.openaiApiKey)
     console.log('AnalysisEngine: Gemini key present:', !!settings.geminiApiKey)
-    
-    if (settings.openaiApiKey || settings.geminiApiKey) {
+
+    if (settings.geminiApiKey) {
       console.log('AnalysisEngine: Initializing LLM service...')
       initializeLLMService().then(() => {
         console.log('AnalysisEngine: LLM service initialization complete')
@@ -375,7 +374,7 @@ export const AnalysisEngine: React.FC<AnalysisEngineProps> = ({
     } else {
       console.log('AnalysisEngine: No API keys available, skipping LLM initialization')
     }
-  }, [settings.openaiApiKey, settings.geminiApiKey, settings.llmProvider, initializeLLMService])
+  }, [settings.geminiApiKey, settings.llmProvider, initializeLLMService])
 
   // Start/stop analysis loop - this is the main effect that controls the analysis
   useEffect(() => {

--- a/src/renderer/components/ConfigPanel.tsx
+++ b/src/renderer/components/ConfigPanel.tsx
@@ -116,9 +116,7 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({
     }
   }
 
-  const isProviderConfigured = settings.llmProvider === 'openai' 
-    ? !!settings.openaiApiKey 
-    : !!settings.geminiApiKey
+  const isProviderConfigured = !!settings.geminiApiKey
 
   const handleInitializeLlm = async () => {
     if (isProviderConfigured) {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -226,29 +226,13 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                 </label>
                 <select
                   value={localSettings.llmProvider}
-                  onChange={(e) => updateLocalSetting('llmProvider', e.target.value as 'openai' | 'gemini')}
+                  onChange={(e) => updateLocalSetting('llmProvider', e.target.value as 'gemini')}
                   className="w-full bg-gray-700 border border-gray-600 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-primary-500"
                 >
-                  <option value="openai">OpenAI GPT-4 Vision</option>
                   <option value="gemini">Google Gemini Vision</option>
                 </select>
               </div>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-2">
-                  OpenAI API Key
-                </label>
-                <input
-                  type="password"
-                  value={localSettings.openaiApiKey}
-                  onChange={(e) => updateLocalSetting('openaiApiKey', e.target.value)}
-                  placeholder="sk-..."
-                  className="w-full bg-gray-700 border border-gray-600 rounded-md px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500"
-                />
-                <p className="text-xs text-gray-400 mt-1">
-                  Get your API key from <a href="https://platform.openai.com" className="text-primary-400 hover:underline">OpenAI Platform</a>
-                </p>
-              </div>
 
               <div>
                 <label className="block text-sm font-medium text-gray-300 mb-2">

--- a/src/renderer/services/external-clients.ts
+++ b/src/renderer/services/external-clients.ts
@@ -1,11 +1,3 @@
-export interface OpenAIClient {
-  chat: {
-    completions: {
-      create: (params: any) => Promise<{ choices: { message: { content: string } }[] }>
-    }
-  }
-}
-
 export interface GeminiModel {
   generateContent: (input: any[]) => Promise<{ response: { text(): string } }>
 }
@@ -14,12 +6,7 @@ export interface GeminiClient {
   getGenerativeModel: (options: { model: string }) => GeminiModel
 }
 
-import OpenAI from 'openai'
 import { GoogleGenerativeAI } from '@google/generative-ai'
-
-export const createDefaultOpenAIClient = (apiKey: string): OpenAIClient => {
-  return new OpenAI({ apiKey, dangerouslyAllowBrowser: true }) as OpenAIClient
-}
 
 export const createDefaultGeminiClient = (apiKey: string): GeminiClient => {
   return new GoogleGenerativeAI(apiKey) as GeminiClient

--- a/src/renderer/stores/sync-store.ts
+++ b/src/renderer/stores/sync-store.ts
@@ -108,8 +108,7 @@ export function createSyncGameCoachStore(client: StateClient = new ElectronState
     },
     isAnalyzing: false,
     lastAnalysis: null,    settings: {
-      llmProvider: 'openai',
-      openaiApiKey: '',
+      llmProvider: 'gemini',
       geminiApiKey: '',
       overlayEnabled: true,
       ttsEnabled: false,
@@ -374,23 +373,17 @@ export function createSyncGameCoachStore(client: StateClient = new ElectronState
       const { settings } = get()
       
       console.log('SyncStore: Preparing LLM config', {
-        hasOpenAI: !!settings.openaiApiKey,
-        hasGemini: !!settings.geminiApiKey,
-        provider: settings.llmProvider
+        hasGemini: !!settings.geminiApiKey
       })
 
       const config: LLMConfig = {
-        openaiApiKey: settings.openaiApiKey,
         geminiApiKey: settings.geminiApiKey,
-        preferredProvider: settings.llmProvider as 'openai' | 'gemini' | 'auto',
         maxRetries: 3,
         timeout: 30000,
       }
 
       try {
         console.log('SyncStore: Initializing LLM service with config:', {
-          provider: config.preferredProvider,
-          hasOpenAI: !!config.openaiApiKey,
           hasGemini: !!config.geminiApiKey
         })
         const llmService = new LLMService(config)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,8 +7,7 @@ export interface ScreenSource {
 }
 
 export interface AppSettings {
-  llmProvider: 'openai' | 'gemini'
-  openaiApiKey: string
+  llmProvider: 'gemini'
   geminiApiKey: string
   overlayEnabled: boolean
   ttsEnabled: boolean
@@ -89,7 +88,7 @@ export interface Advice {
   category?: 'combat' | 'exploration' | 'items' | 'general'
   confidence: number
   timestamp: number
-  provider: 'openai' | 'gemini'
+  provider: 'gemini'
   analysisTime?: number
 }
 
@@ -119,7 +118,7 @@ export interface AnalysisRequest {
 export interface AnalysisResponse {
   advice: string
   confidence: number
-  provider: 'openai' | 'gemini'
+  provider: 'gemini'
   timestamp: number
   analysisTime: number
 }

--- a/tests/ConfigPanel.test.tsx
+++ b/tests/ConfigPanel.test.tsx
@@ -20,7 +20,7 @@ describe('ConfigPanel component', () => {
       getCaptureSources: vi.fn().mockResolvedValue([]),
     }
     mockUseStore.mockReturnValue({
-      settings: { overlayEnabled: true, llmProvider: 'openai', openaiApiKey: 'k', geminiApiKey: '' },
+      settings: { overlayEnabled: true, llmProvider: 'gemini', geminiApiKey: 'k' },
       isAnalyzing: false,
       gameDetection: null,
       lastAnalysis: null,

--- a/tests/SettingsModal.test.tsx
+++ b/tests/SettingsModal.test.tsx
@@ -16,8 +16,7 @@ vi.mock('../src/renderer/stores/sync-store', () => ({
 }))
 
 const settings = {
-  llmProvider: 'openai',
-  openaiApiKey: '',
+  llmProvider: 'gemini',
   geminiApiKey: '',
   overlayEnabled: true,
   ttsEnabled: false,

--- a/tests/llm-service.test.ts
+++ b/tests/llm-service.test.ts
@@ -1,14 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { LLMService, type LLMConfig } from '../src/renderer/services/llm-service'
 
-vi.mock('openai', () => {
-  return {
-    default: class {
-      chat = { completions: { create: vi.fn(async () => ({ choices: [{ message: { content: 'ok' } }] })) } }
-    }
-  }
-})
-
 vi.mock('@google/generative-ai', () => {
   return {
     GoogleGenerativeAI: class {
@@ -26,9 +18,7 @@ describe('LLMService retryWithBackoff', () => {
   it('retries until success', async () => {
     vi.useFakeTimers()
     const service = new LLMService({
-      openaiApiKey: 'k',
-      geminiApiKey: undefined,
-      preferredProvider: 'openai',
+      geminiApiKey: 'k',
       maxRetries: 2,
       timeout: 0
     } as LLMConfig)
@@ -49,9 +39,7 @@ describe('LLMService retryWithBackoff', () => {
   it('throws after max retries', async () => {
     vi.useFakeTimers()
     const service = new LLMService({
-      openaiApiKey: 'k',
-      geminiApiKey: undefined,
-      preferredProvider: 'openai',
+      geminiApiKey: 'k',
       maxRetries: 1,
       timeout: 0
     } as LLMConfig)
@@ -67,9 +55,7 @@ describe('LLMService retryWithBackoff', () => {
 
 describe('LLMService calculateConfidence', () => {
   const service = new LLMService({
-    openaiApiKey: 'k',
-    geminiApiKey: undefined,
-    preferredProvider: 'openai',
+    geminiApiKey: 'k',
     maxRetries: 0,
     timeout: 0
   } as LLMConfig)
@@ -84,43 +70,5 @@ describe('LLMService calculateConfidence', () => {
     const c = (service as any).calculateConfidence(text)
     expect(c).toBeGreaterThan(0.7)
     expect(c).toBeLessThanOrEqual(1)
-  })
-})
-
-describe('LLMService provider selection', () => {
-  it('selects preferred provider when configured', () => {
-    const service = new LLMService({
-      openaiApiKey: 'a',
-      geminiApiKey: 'b',
-      preferredProvider: 'gemini',
-      maxRetries: 0,
-      timeout: 0
-    } as LLMConfig)
-
-    const provider = (service as any).selectProvider()
-    expect(provider?.name).toBe('gemini')
-  })
-
-  it('falls back to first available provider in auto mode', () => {
-    const service = new LLMService({
-      openaiApiKey: 'a',
-      geminiApiKey: 'b',
-      preferredProvider: 'auto',
-      maxRetries: 0,
-      timeout: 0
-    } as LLMConfig)
-    const provider = (service as any).selectProvider()
-    expect(provider?.name).toBe('openai')
-  })
-
-  it('returns null when preferred provider missing', () => {
-    const service = new LLMService({
-      geminiApiKey: 'b',
-      preferredProvider: 'openai',
-      maxRetries: 0,
-      timeout: 0
-    } as LLMConfig)
-    const provider = (service as any).selectProvider()
-    expect(provider).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- drop OpenAI client and config options
- simplify LLMService to use Gemini only
- clean up state and components to remove OpenAI API key
- update unit tests for Gemini-only logic

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68498d03cb388326ba769d6b0037a27c