### PR TITLE
Simplify analysis prompt handling

### DIFF
--- a/src/renderer/stores/sync-store.ts
+++ b/src/renderer/stores/sync-store.ts
@@ -311,9 +311,7 @@ export function createSyncGameCoachStore(client: StateClient = new ElectronState
       })
 
       const config: LLMConfig = {
-        geminiApiKey: settings.geminiApiKey,
-        maxRetries: 3,
-        timeout: 30000,
+        geminiApiKey: settings.geminiApiKey
       }
 
       try {

--- a/tests/AnalysisEngine.test.tsx
+++ b/tests/AnalysisEngine.test.tsx
@@ -5,7 +5,6 @@ import AnalysisEngine from '../src/renderer/components/AnalysisEngine'
 
 var mockUseStore: any
 var captureMock: any
-var getHUDRegionsMock: any
 vi.mock('../src/renderer/stores/sync-store', () => ({
   useSyncGameCoachStore: () => mockUseStore()
 }))
@@ -17,14 +16,6 @@ vi.mock('../src/renderer/services/screen-capture-renderer', () => {
       captureFrame: (...args: any[]) => captureMock(...args),
       startCapture: vi.fn(),
       stopCapture: vi.fn()
-    }
-  }
-})
-vi.mock('../src/renderer/services/game-template-service', () => {
-  getHUDRegionsMock = vi.fn(async () => [])
-  return {
-    GameTemplateService: class {
-      getHUDRegions = getHUDRegionsMock
     }
   }
 })
@@ -49,7 +40,6 @@ describe('AnalysisEngine prompt usage', () => {
   beforeEach(() => {
     mockUseStore = vi.fn()
     captureMock.mockClear()
-    getHUDRegionsMock.mockClear()
   })
 
   it('calls analyzeGameplay with system instruction', async () => {
@@ -84,8 +74,7 @@ describe('AnalysisEngine prompt usage', () => {
 
     process.env.NODE_ENV = 'development'
     const screenClient = { getCaptureSources: vi.fn(), captureFrame: vi.fn().mockResolvedValue(undefined) }
-    const templateClient = {}
-    render(<AnalysisEngine isEnabled={false} screenSourceClient={screenClient as any} templateClient={templateClient as any} />)
+    render(<AnalysisEngine isEnabled={false} screenSourceClient={screenClient as any} />)
 
     // debugTestLLM is attached to window in development mode
     await act(async () => {
@@ -93,7 +82,7 @@ describe('AnalysisEngine prompt usage', () => {
     })
 
     expect(analyzeGameplay).toHaveBeenCalledWith(
-      expect.objectContaining({ customInstructions: 'basic prompt' })
+      expect.objectContaining({ prompt: 'basic prompt' })
     )
   })
 })

--- a/tests/llm-service.test.ts
+++ b/tests/llm-service.test.ts
@@ -17,11 +17,7 @@ vi.mock('@google/generative-ai', () => {
 describe('LLMService retryWithBackoff', () => {
   it('retries until success', async () => {
     vi.useFakeTimers()
-    const service = new LLMService({
-      geminiApiKey: 'k',
-      maxRetries: 2,
-      timeout: 0
-    } as LLMConfig)
+    const service = new LLMService({ geminiApiKey: 'k' } as LLMConfig)
 
     const op = vi.fn()
       .mockRejectedValueOnce(new Error('e1'))
@@ -38,11 +34,7 @@ describe('LLMService retryWithBackoff', () => {
 
   it('throws after max retries', async () => {
     vi.useFakeTimers()
-    const service = new LLMService({
-      geminiApiKey: 'k',
-      maxRetries: 1,
-      timeout: 0
-    } as LLMConfig)
+    const service = new LLMService({ geminiApiKey: 'k' } as LLMConfig)
     const op = vi.fn().mockRejectedValue(new Error('fail'))
     const promise = (service as any).retryWithBackoff(op, 1)
     promise.catch(() => {})
@@ -54,11 +46,7 @@ describe('LLMService retryWithBackoff', () => {
 })
 
 describe('LLMService calculateConfidence', () => {
-  const service = new LLMService({
-    geminiApiKey: 'k',
-    maxRetries: 0,
-    timeout: 0
-  } as LLMConfig)
+  const service = new LLMService({ geminiApiKey: 'k' } as LLMConfig)
 
   it('returns low confidence for short advice', () => {
     const c = (service as any).calculateConfidence('short')


### PR DESCRIPTION
## Summary
- streamline `AnalysisRequest` to only include `imageBuffer` and `prompt`
- remove template service usage from `AnalysisEngine`
- make `LLMService` require only a Gemini key and default retries
- adjust store initialization for new `LLMService` config
- update related unit tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_684addc9f88c8326bd4255d0af4a893d